### PR TITLE
Update index.html -- fix quick install

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,8 +75,8 @@
       </p>
 
       <p>Quick install:
-      <pre>$ curl -o PKGBUILD http://aur.archlinux.org/packages/co/cower/PKGBUILD && makepkg -si
-$ curl -o PKGBUILD http://aur.archlinux.org/packages/pa/pacaur/PKGBUILD && makepkg -si</pre>
+      <pre>$ curl -o PKGBUILD --insecure https://aur.archlinux.org/packages/co/cower/PKGBUILD && makepkg -si
+$ curl -o PKGBUILD --insecure https://aur.archlinux.org/packages/pa/pacaur/PKGBUILD && makepkg -si</pre>
 
       </p>
     


### PR DESCRIPTION
aur.archlinux.org is now redirecting http to https, 
breaking the quick install.
Furthermore, the cert can not be verified by curl 
(at least on a fresh Arch install), so --insecure is needed.
