### PR TITLE
Fix sorting of CheckAur()

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -621,13 +621,14 @@ CheckAur() {
     if [[ -n "${aurpkgsQood[@]}" ]]; then
         [[ $quiet ]] && echo "${aurpkgsQood[@]}" | tr ' ' '\n' && return
         downloadjson ${aurpkgsQood[@]}
+        aurpkgsAname=($(getjsonvar "Name"))    # return sorted results
         aurpkgsAver=($(getjsonvar "Version"))
-        aurpkgsQver=($(expac -Q '%v' "${aurpkgsQood[@]}"))
-        [[ ! $lname ]] && lname=$(getlength ${aurpkgsQood[@]})
+        aurpkgsQver=($(expac -Q '%v' "${aurpkgsAname[@]}"))
+        [[ ! $lname ]] && lname=$(getlength ${aurpkgsAname[@]})
         [[ ! $lver ]] && lver=$(getlength ${aurpkgsQver[@]} ${aurpkgSver[@]})
         [[ ! $lrepo ]] && lrepo=3
-        for ((i=0; i<${#aurpkgsQood[@]}; i++)); do
-            printf "${colorB}::${reset} ${colorM}%-${lrepo}s${reset}  ${colorW}%-${lname}s${reset}  ${colorR}%-${lver}s${reset}  ->  ${colorG}%-${lver}s${reset}\n" "aur" "${aurpkgsQood[$i]}" "${aurpkgsQver[$i]}" "${aurpkgsAver[$i]}"
+        for ((i=0; i<${#aurpkgsAname[@]}; i++)); do
+            printf "${colorB}::${reset} ${colorM}%-${lrepo}s${reset}  ${colorW}%-${lname}s${reset}  ${colorR}%-${lver}s${reset}  ->  ${colorG}%-${lver}s${reset}\n" "aur" "${aurpkgsAname[$i]}" "${aurpkgsQver[$i]}" "${aurpkgsAver[$i]}"
         done
     fi
 }


### PR DESCRIPTION
Fixes intermittent mismatch of packages and package versions when using '-Qu'.
Don't implicitly trust JSON result to be sorted the same way as they where requested.

example:

```
$ pacaur -Qu
...
:: extra      qtwebkit                          2.3.0-1    ->  2.3.1-1
:: extra      sip                               4.14.5-1   ->  4.14.6-1
:: extra      udisks2                           2.0.1-1    ->  2.1.0-1
:: aur        sxhkd                             0.2-2      ->  4.1.4-1
:: aur        pacaur                            4.1.3-1    ->  0.3-1
```

after patch:

```
$ pacaur -Qu
...
:: extra      qtwebkit                          2.3.0-1    ->  2.3.1-1
:: extra      sip                               4.14.5-1   ->  4.14.6-1
:: extra      udisks2                           2.0.1-1    ->  2.1.0-1
:: aur        pacaur                            4.1.3-1    ->  4.1.4-1
:: aur        sxhkd                             0.2-2      ->  0.3-1
```

this merely copies from elsewhere in `pacaur`.

If you would ever want to do some more complicated parsing this is where I got before I found the easier fix by further reading of `pacaur`, consider this unrelated to this patch:

```
IFS='
'
arr=($(</tmp/pacaurtmp-$USER/raw.json sed -e 's/.*\"results\":\[//' | sed -e 's/]}$//' | sed -e 's/},{/}\n{/'))

for ((i=0; i<${#arr[@]}; i++)); do
    json_reformat <<< "${arr[$i]}"
done
```
