### PR TITLE
fixed find installscript depth

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -748,7 +748,7 @@ getignoredpkgs() {
 getinstallscript() {
     [[ ! -d "$builddir/$1" ]] && return
     unset installscriptpath installscript
-    installscriptpath=$(find "$builddir/$1/" -name "*.install")
+    installscriptpath=$(find "$builddir/$1/" -maxdepth 1 -name "*.install")
     [[ $installscriptpath ]] && installscript=$(basename $installscriptpath)
 }
 


### PR DESCRIPTION
Going too deep when looking for install script:
- is inefficient
- yield errors when pkg is 000 (after makepkg failure)
- brings .install files that are not pacman install scripts
