### PR TITLE
Add msg2() function which is used on several packages

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -800,6 +800,10 @@ msg() {
     esac
 }
 
+msg2() {
+    msg i "${@}"
+}
+
 getlength() {
     local length=0
     for i in "$@"; do


### PR DESCRIPTION
I've encountered several packages, on the AUR at least, that use "msg2" as some kind of alias to "msg i".

So here's a simple patch that adds that and turn the messages visible, otherwise it would just printout "command not found".
