### PR TITLE
add AUR package completion to zsh.completion

### DIFF
--- a/zsh.completion
+++ b/zsh.completion
@@ -165,7 +165,7 @@ _pacaur_opts_sync_modifiers=(
     {-w,--downloadonly}'[Download packages only]'
     {\*-y,\*--refresh}'[Download fresh package databases]'
     {-q,--quiet}'[Show less information]'
-    '*--ignore[Ignore a package upgrade]:package: _pacaur_completions_all_packages'
+    '*--ignore[Ignore a package upgrade]:package: _pacaur_all_packages'
     '*--ignoregroup[Ignore a group upgrade]:package group:_pacaur_completions_all_groups'
     '--asdeps[Install packages as non-explicitly installed]'
     '--asexplicit[Install packages as explicitly installed]'
@@ -285,7 +285,7 @@ _pacaur_action_sync() {
                 "$_pacaur_opts_extended[@]" \
                 "$_pacaur_opts_sync_actions[@]" \
                 "$_pacaur_opts_sync_modifiers[@]" \
-                '*:package:_pacaur_completions_all_packages'
+                '*:packages:_pacaur_remote_packages'
             ;;
     esac
 }
@@ -355,6 +355,13 @@ _pacaur_completions_all_packages() {
     fi
 }
 
+_pacaur_completions_aur_packages() {
+    zstyle -T ":completion:${curcontext}:" remote-access || return 1
+    local -a aur_packages
+    aur_packages=($(_call_program packages cower -sq $words[CURRENT] 2>/dev/null))
+    _wanted aur_packages expl "aur packages" compadd - "${(@)aur_packages}"
+}
+
 # provides completions for package groups
 _pacaur_completions_installed_groups() {
     local -a cmd groups
@@ -375,6 +382,13 @@ _pacaur_completions_installed_packages() {
 _pacaur_all_packages() {
     _alternative : \
         'localpkgs:local packages:_pacaur_completions_installed_packages' \
+        'aurpkgs:aur packages:_pacaur_completions_aur_packages' \
+        'repopkgs:repository packages:_pacaur_completions_all_packages'
+}
+
+_pacaur_remote_packages() {
+    _alternative : \
+        'aurpkgs:aur packages:_pacaur_completions_aur_packages' \
         'repopkgs:repository packages:_pacaur_completions_all_packages'
 }
 


### PR DESCRIPTION
Uses cower to list matching AUR packages.

You can disable AUR completion using the following zstyle:

``` zsh
zstyle ':completion:*:pacaur:*' remote-access false
```

The name `remote-access` mimics other completion zstyles like `_cvs` and `_scp` that use this for deciding whether to complete remote files or not.

Closes #269.

I've been trying to fix #236 as well but I still haven't found a nice way to do so.
