### PR TITLE
implement --skippgpcheck for packages with a sig but no local key

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -159,6 +159,10 @@ option.
 Always rebuild packages regardless of any existing file in I<$PKGDEST> directory,
 and regardless of up-to-date status of development packages.
 
+=item B<--skippgpcheck>
+
+Do not verify PGP signatures of source files when running makepkg.
+
 =item B<--ignore-ood>
 
 When searching the AUR, ignore all results marked as out of date.

--- a/bash.completion
+++ b/bash.completion
@@ -30,7 +30,7 @@ _pacaur() {
     _pacman &> /dev/null
     if [[ "$cur" == -* ]]; then
         case "$op" in
-            S) _arch_compgen "${COMPREPLY[@]}" "-a --aur -r --repo -e --edit --devel --noconfirm --noedit --rebuild";;
+            S) _arch_compgen "${COMPREPLY[@]}" "-a --aur -r --repo -e --edit --devel --noconfirm --noedit --rebuild --skippgpcheck";;
             Q) _arch_compgen "${COMPREPLY[@]}" "-a --aur -r --repo";;
         esac
     else

--- a/pacaur
+++ b/pacaur
@@ -1052,6 +1052,7 @@ usage() {
     printf "%s\n" $"   --noconfirm      do not prompt for any confirmation"
     printf "%s\n" $"   --noedit         do not prompt to edit files"
     printf "%s\n" $"   --rebuild        always rebuild package(s)"
+    printf "%s\n" $"   --skippgpcheck   do not verify PGP signature(s) of source files"
     echo
 }
 
@@ -1103,6 +1104,7 @@ while [[ -n "${!OPTIND}" ]]; do
                     noconfirm) noconfirm=true; pacopts+=("--noconfirm");;
                     noedit) noedit=true;;
                     rebuild) rebuild=true;;
+                    skippgpcheck) makeopts+=("--skippgpcheck");;
                     root) root=true;;
                     version) version; exit;;
                     help) usage; exit;;

--- a/zsh.completion
+++ b/zsh.completion
@@ -72,6 +72,7 @@ _pacaur_opts_extended=(
     {-r,--repo}'[Only search, install or clean packages from the repositories]'
     '--noedit[Do not prompt to edit files]'
     '--rebuild[Always rebuild package(s)]'
+    '--skippgpcheck[Do not verify PGP signature(s) of source files]'
 )
 
 _pacaur_opts_extended_update=(


### PR DESCRIPTION
Some packages (such as `cower` and `pkg_scripts`) implement PGP/GPG keys in AUR, however if you do not have those authors' keys imported to your local database then makepkg will error out trying to verify the source. This pull request adds `--skippgpcheck` to pacaur and passes it to `makepkg` directly via the makeopts[] array to allow bypassing the PGP/GPG check during build.