### PR TITLE
use --noconfirm rather than yes

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -754,7 +754,7 @@ MakePkgs() {
             for j in "${VCSCLIENTS[@]}"; do
                 if [[ ! "${vcschecked[@]}" =~ "$vcspkg" && $(awk -F "::" '{print $1}' <<< $j) == "$vcspkg" ]]; then
                     vcsclient=$(awk -F "::" '{print $NF}' <<< $j) && vcschecked+=($vcspkg)
-                    [[ -z "$(expac -Qs '%n' "^$vcsclient$")" ]] && yes $(gettext pacman Y) | sudo $pacmanbin -S $vcsclient --asdeps
+                    [[ -z "$(expac -Qs '%n' "^$vcsclient$")" ]] && sudo $pacmanbin -S $vcsclient --asdeps --noconfirm
                 fi
             done
         fi
@@ -784,7 +784,7 @@ MakePkgs() {
     # install provider packages
     if [[ -n "${providerspkgs[@]}" ]]; then
         Note "i" $"Installing ${colorW}${providerspkgs[@]}${reset} dependencies..."
-        yes $(gettext pacman Y) | sudo $pacmanbin -S ${providerspkgs[@]} --asdeps
+        sudo $pacmanbin -S ${providerspkgs[@]} --asdeps --noconfirm
     fi
 
     # main
@@ -836,7 +836,7 @@ MakePkgs() {
             if [[ $cachedpkg ]]; then
                 if [[ " ${aurdepspkgs[@]} " =~ " $j " || $installpkg ]]; then
                     Note "i" $"Installing ${colorW}$j${reset} cached package..."
-                    yes $(gettext pacman Y) | sudo $pacmanbin -U $cachedpkg ${pacopts[@]}
+                    sudo $pacmanbin -U $cachedpkg ${pacopts[@]} --noconfirm
                     [[ ! " ${aurpkgs[@]} " =~ " $j " ]] && sudo $pacmanbin -D $j --asdeps ${pacopts[@]} &>/dev/null
                 else
                     Note "w" $"Package ${colorW}$j${reset} already available in cache"
@@ -853,9 +853,9 @@ MakePkgs() {
         if [[ $installpkg ]]; then
             # install
             if [[ $silent = true ]]; then
-                yes $(gettext pacman Y) | makepkg -sfi ${makeopts[@]} --pkg ${pkgsdeps[$i]} &>/dev/null
+                makepkg --noconfirm -sfi ${makeopts[@]} --pkg ${pkgsdeps[$i]} &>/dev/null
             else
-                yes $(gettext pacman Y) | makepkg -sfi ${makeopts[@]} --pkg ${pkgsdeps[$i]}
+                makepkg --noconfirm -sfi ${makeopts[@]} --pkg ${pkgsdeps[$i]}
             fi
         else
             unset isaurdeps
@@ -866,16 +866,16 @@ MakePkgs() {
                 # install AUR deps
                 Note "i" $"Installing ${colorW}${pkgsdeps[$i]}${reset} dependencies..."
                 if [[ $silent = true ]]; then
-                    yes $(gettext pacman Y) | makepkg -sfi ${makeopts[@]} --pkg ${pkgsdeps[$i]} &>/dev/null
+                    makepkg --noconfirm -sfi ${makeopts[@]} --pkg ${pkgsdeps[$i]} &>/dev/null
                 else
-                    yes $(gettext pacman Y) | makepkg -sfi ${makeopts[@]} --pkg ${pkgsdeps[$i]}
+                    makepkg --noconfirm -sfi ${makeopts[@]} --pkg ${pkgsdeps[$i]}
                 fi
             else
                 # install then remove binary deps
                 if [[ $silent = true ]]; then
-                    yes $(gettext pacman Y) | makepkg -sfr ${makeopts[@]} --pkg ${pkgsdeps[$i]} &>/dev/null
+                    makepkg --noconfirm -sfr ${makeopts[@]} --pkg ${pkgsdeps[$i]} &>/dev/null
                 else
-                    yes $(gettext pacman Y) | makepkg -sfr ${makeopts[@]} --pkg ${pkgsdeps[$i]}
+                    makepkg --noconfirm -sfr ${makeopts[@]} --pkg ${pkgsdeps[$i]}
                 fi
             fi
         fi


### PR DESCRIPTION
It occurred to me that we actually don’t need to use `yes` at all, we can
simply pass `--noconfirm` to `pacman` and `makepkg`.