### PR TITLE
Missing '>'

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -430,4 +430,4 @@ B<[ru] - Русский> - "kyak"
 
 B<[tr] - Türkçe> - Volkan "wakeup" Gezer
 
-B<[nl] - Nederlands - "Yoshi2889"
+B<[nl] - Nederlands> - "Yoshi2889"


### PR DESCRIPTION
```
./README.pod around line 433: Unterminated B<...> sequence
```