### PR TITLE
Fix displaybuildfiles=diff: --ff and git-diff

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -796,7 +796,7 @@ DownloadPkgs() {
             cd "$clonedir/$i" || exit 1
             [[ -e ".git/FETCH_HEAD" && $displaybuildfiles = diff ]] && cp -pf ".git/FETCH_HEAD" ".git/FETCH_HEAD.prev"
             git reset --hard HEAD -q # updated pkgver of vcs packages prevent pull
-            git pull -q
+            git pull --ff -q
         fi
     done
 }

--- a/pacaur
+++ b/pacaur
@@ -794,8 +794,10 @@ DownloadPkgs() {
             fi
         else
             cd "$clonedir/$i" || exit 1
-            [[ -e ".git/FETCH_HEAD" && $displaybuildfiles = diff ]] && cp -pf ".git/FETCH_HEAD" ".git/FETCH_HEAD.prev"
             git reset --hard HEAD -q # updated pkgver of vcs packages prevent pull
+            if [[ "$displaybuildfiles" = diff ]]; then
+              git rev-parse HEAD > ".git/HEAD.prev"
+            fi
             git pull --ff -q
         fi
     done
@@ -813,12 +815,12 @@ EditPkgs() {
         GetInstallScripts $i
         if [[ ! $edit ]]; then
             if [[ ! $displaybuildfiles = none ]]; then
-                if [[ -e ".git/FETCH_HEAD.prev" && $displaybuildfiles = diff ]]; then
+                if [[ $displaybuildfiles = diff && -e ".git/HEAD.prev" ]]; then
                     # show diff
-                    timestamp=$(stat -c %Y "$clonedir/$i/.git/FETCH_HEAD.prev")
-                    if [[ -n "$(git show --since $timestamp)" ]]; then
+                    diff_cmd="git diff $(cut -f1 .git/HEAD.prev) . ':!\.SRCINFO'"
+                    if [[ -n "$($diff_cmd)" ]]; then
                         if Proceed "y" $"View $i build files diff?"; then
-                            git show --since $timestamp . ':!\.SRCINFO'
+                            $diff_cmd
                             Note "s" $"${colorW}$i${reset} build files diff viewed"
                             viewed='true'
                         fi


### PR DESCRIPTION
1. Use `--ff` with git-pull to override merge.ff=no from config.

    With `merge.ff=no` in a users config, git-pull will create merge commits by default, which is not what we want here.

2. Use HEAD rev and git-diff to show build files diff

 - `FETCH_HEAD` would not change in case git-pull was aborted/reset.
 - git-show only displays a single commit, which works by default, but
   not in case a merge commit was used.  While this is fixed in e7b3c7b
   for me, `git-diff` seems to be more sensible here still, especially
   since it avoids using a timestamp.
