### PR TITLE
Use shallow git clones

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -787,11 +787,7 @@ DownloadPkgs() {
     for i in ${basepkgs[@]}; do
         cd "$clonedir" || exit 1
         if [[ ! -d "$i" ]]; then
-            if [[ $clonedir != $tmpdir ]]; then
-                git clone https://aur.archlinux.org/$i.git
-            else
-                git clone --depth=1 https://aur.archlinux.org/$i.git
-            fi
+            git clone --depth=1 https://aur.archlinux.org/$i.git
         else
             cd "$clonedir/$i" || exit 1
             [[ -e ".git/FETCH_HEAD" && $displaybuildfiles = diff ]] && cp -pf ".git/FETCH_HEAD" ".git/FETCH_HEAD.prev"


### PR DESCRIPTION
I have the feeling this might have been missed in 63f4251, where the
default for `$clonedir` was changed.

Since it is easy to unshallow a shallow clone using `git fetch
--unshallow`, this should be used by default.