### PR TITLE
Clarify error in `GetJson`: "Failed to parse JSON"

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1280,7 +1280,7 @@ GetJson() {
                 sed -e "/^\"$3\"/,/]/!d" | tr -d '\"' | tr '\n' ' ' | cut -d' ' -f 2- | tr -d '[]';;
         esac
     else
-        Note "e" "Could not connect to the AUR"
+        Note "e" "Failed to parse JSON."
     fi
 }
 


### PR DESCRIPTION
The "Could not connect to the AUR" error message could/should be
provided by the actual `curl` wrapper and/or by checking for an empty
JSON document.