### PR TITLE
Fixed noun gender in Slovak translation.

### DIFF
--- a/po/sk.po
+++ b/po/sk.po
@@ -25,7 +25,7 @@ msgstr ""
 
 #: pacaur:159 pacaur:215 pacaur:1139
 msgid "latest"
-msgstr "najnovší"
+msgstr "najnovšia"
 
 #: pacaur:164
 msgid "${checkaurpkgs[$i]} is in IgnorePkg/IgnoreGroup. Install anyway?"


### PR DESCRIPTION
Since "latest" is referring to "version", which is a she, "latest" needs to be a she too.
