### PR TITLE
Fix #490.

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1505,7 +1505,7 @@ while [[ -n "${!OPTIND}" ]]; do
         esac
     done
     # packages
-    [[ -z "${!OPTIND}" ]] && break || pkgs+=(${!OPTIND})
+    [[ -z "${!OPTIND}" ]] && break || pkgs+=("${!OPTIND}")
     shift $OPTIND
     OPTIND=1
 done


### PR DESCRIPTION
44fa07a6ee96c1d6d58b1b774e55263064e3cf72 wasn't enough.