### PR TITLE
Make input prompts always consistent with pacman's

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1304,14 +1304,14 @@ Proceed() {
     N="$(gettext pacman N)"; n="${N,,}"
     case "$1" in
         y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [Y/n] "
-            [[ $cleancache ]] && read -r answer || read -r -n 1 answer
+            read -r answer
             echo
             case $answer in
                 $Y|$y|'') return 0;;
                 *) return 1;;
             esac;;
         n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [y/N] "
-            [[ $cleancache ]] && read -r answer || read -r -n 1 answer
+            read -r answer
             echo
             case $answer in
                 $N|$n|'') return 0;;


### PR DESCRIPTION
When prompting `Proceed? [Y/n]` pacaur gets input via a <code>read -r <b>-n 1</b></code> command. This causes the operation to continue immediately as soon as a key is pressed, rather than after the user presses return. This is inconsistent with the way pacman does it, and in my opinion error prone. It's already been made consistent for a subset of commands in commit 5d5c502, by removing the `-n 1` argument to `read` conditionally. This pull request fixes this in general.