### PR TITLE
Automatically split the request for package info into URI lengths les    

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1276,7 +1276,7 @@ DownloadJson() {
         do
           #If the current curl request plus the string plus the package name is 
           #greater than or equal to the max, then start the next curl request
-          if [ "$((${#curlreq[i]} + ${#string} + ${#package}))" -ge "$max" ]; then
+          if [ "$((${#curlreq[index]} + ${#string} + ${#package}))" -ge "$max" ]; then
             index=$(($index + 1))
           fi
 
@@ -1284,7 +1284,7 @@ DownloadJson() {
           curlreq[$index]=${curlreq[$index]}$string$package
         done
         #set https part of url
-        local https="https//"
+        local https="https://"
         local index=0
         for request in ${curlreq[@]}
         do
@@ -1292,12 +1292,12 @@ DownloadJson() {
           index=$(($index+1))
         done
         curl -sfg --compressed -C 0 ${urlreq[@]} \
-            | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g'
-    fi
+            | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g' | tee output
+      fi
 }
 
 GetJson() {
-    if json_verify -q <<< "$2"; then
+    if json_verify  <<< "$2"; then
         case "$1" in
             var)
                 json_reformat <<< "$2" | tr -d "\", " | grep -Po "$3:.*" | sed -r "s/$3:/$3#/g" | awk -F "#" '{print $2}';;

--- a/pacaur
+++ b/pacaur
@@ -1292,7 +1292,7 @@ DownloadJson() {
           index=$(($index+1))
         done
         curl -sfg --compressed -C 0 ${urlreq[@]} \
-            | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g' | tee output
+            | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g'
       fi
 }
 

--- a/pacaur
+++ b/pacaur
@@ -1252,48 +1252,48 @@ GetPkgbase() {
 }
 
 DownloadJson() {
-    local urlencodedpkgs urlargs
-    urlencodedpkgs=($(sed 's/+/%2b/g;s/@/%40/g' <<< $@)) # pkgname consists of alphanum@._+-
-    urlargs="$(printf "&arg[]=%s" "${urlencodedpkgs[@]}")"
-    # ensure the URI length is shorter than 8190 bytes (52 for AUR path, 13 reserved)
-    if [[ "${#urlargs}" -lt 8125 ]]; then
-        curl -sfg --compressed -C 0 "https://$aururl$aurrpc$urlargs"
-    else
-        # split and merge json stream
+  local urlencodedpkgs urlargs
+  urlencodedpkgs=($(sed 's/+/%2b/g;s/@/%40/g' <<< $@)) # pkgname consists of alphanum@._+-
+  urlargs="$(printf "&arg[]=%s" "${urlencodedpkgs[@]}")"
+  # ensure the URI length is shorter than 8190 bytes (52 for AUR path, 13 reserved)
+  if [[ "${#urlargs}" -lt 8125 ]]; then
+    curl -sfg --compressed -C 0 "https://$aururl$aurrpc$urlargs"
+  else
+    # split and merge json stream
 
-        urlpkgs=($@)
-        #Transform the array int a string
-        local urlstring=$( IFS=$'\n'; echo "${urlpkgs[*]}" )
+    urlpkgs=($@)
+    #Transform the array int a string
+    local urlstring=$( IFS=$'\n'; echo "${urlpkgs[*]}" )
 
-        #Maximum size of URI, 8000 just for safety, could be increased with
-        #caution
-        local max=8000 
-        #string to append to each entry
-        local string='&arg[]='
-        local index=0
-        #for each package
-        for package in $urlstring
-        do
-          #If the current curl request plus the string plus the package name is 
-          #greater than or equal to the max, then start the next curl request
-          if [ "$((${#curlreq[index]} + ${#string} + ${#package}))" -ge "$max" ]; then
-            index=$(($index + 1))
-          fi
-
-          #Append the new string,package to the current curl request
-          curlreq[$index]=${curlreq[$index]}$string$package
-        done
-        #set https part of url
-        local https="https://"
-        local index=0
-        for request in ${curlreq[@]}
-        do
-          urlreq[$index]=$https$aururl$aurrpc${curlreq[$index]}
-          index=$(($index+1))
-        done
-        curl -sfg --compressed -C 0 ${urlreq[@]} \
-            | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g'
+    #Maximum size of URI, 8000 just for safety, could be increased with
+    #caution
+    local max=8000 
+    #string to append to each entry
+    local string='&arg[]='
+    local index=0
+    #for each package
+    for package in $urlstring
+    do
+      #If the current curl request plus the string plus the package name is 
+      #greater than or equal to the max, then start the next curl request
+      if [ "$((${#curlreq[index]} + ${#string} + ${#package}))" -ge "$max" ]; then
+        index=$(($index + 1))
       fi
+
+      #Append the new string,package to the current curl request
+      curlreq[$index]=${curlreq[$index]}$string$package
+    done
+    #set https part of url
+    local https="https://"
+    local index=0
+    for request in ${curlreq[@]}
+    do
+      urlreq[$index]=$https$aururl$aurrpc${curlreq[$index]}
+      index=$(($index+1))
+    done
+    curl -sfg --compressed -C 0 ${urlreq[@]} \
+      | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g'
+  fi
 }
 
 GetJson() {

--- a/pacaur
+++ b/pacaur
@@ -1297,7 +1297,7 @@ DownloadJson() {
 }
 
 GetJson() {
-    if json_verify  <<< "$2"; then
+    if json_verify -q  <<< "$2"; then
         case "$1" in
             var)
                 json_reformat <<< "$2" | tr -d "\", " | grep -Po "$3:.*" | sed -r "s/$3:/$3#/g" | awk -F "#" '{print $2}';;

--- a/pacaur
+++ b/pacaur
@@ -1292,6 +1292,7 @@ DownloadJson() {
       index=$(($index+1))
     done
     curl -sfg --compressed -C 0 ${urlreq[@]} \
+      | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g' \
       | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g'
   fi
 }

--- a/pacaur
+++ b/pacaur
@@ -1259,14 +1259,39 @@ DownloadJson() {
     if [[ "${#urlargs}" -lt 8125 ]]; then
         curl -sfg --compressed -C 0 "https://$aururl$aurrpc$urlargs"
     else
-        local urlencodedpkgs1 urlencodedpkgs2 urlargs1 urlargs2
         # split and merge json stream
+
         urlpkgs=($@)
-        urlencodedpkgs1=($(sed 's/+/%2b/g;s/@/%40/g' <<< ${urlpkgs[@]:0:$((${#urlpkgs[@]}/2))}))
-        urlencodedpkgs2=($(sed 's/+/%2b/g;s/@/%40/g' <<< ${urlpkgs[@]:$((${#urlpkgs[@]}/2))}))
-        urlargs1="$(printf "&arg[]=%s" "${urlencodedpkgs1[@]}")"
-        urlargs2="$(printf "&arg[]=%s" "${urlencodedpkgs2[@]}")"
-        curl -sfg --compressed -C 0 "https://$aururl$aurrpc$urlargs1" "https://$aururl$aurrpc$urlargs2" \
+        #Transform the array int a string
+        local urlstring=$( IFS=$'\n'; echo "${urlpkgs[*]}" )
+
+        #Maximum size of URI, 8000 just for safety, could be increased with
+        #caution
+        local max=8000 
+        #string to append to each entry
+        local string='&arg[]='
+        local index=0
+        #for each package
+        for package in $urlstring
+        do
+          #If the current curl request plus the string plus the package name is 
+          #greater than or equal to the max, then start the next curl request
+          if [ "$((${#curlreq[i]} + ${#string} + ${#package}))" -ge "$max" ]; then
+            index=$(($index + 1))
+          fi
+
+          #Append the new string,package to the current curl request
+          curlreq[$index]=${curlreq[$index]}$string$package
+        done
+        #set https part of url
+        local https="https//"
+        local index=0
+        for request in ${curlreq[@]}
+        do
+          urlreq[$index]=$https$aururl$aurrpc${curlreq[$index]}
+          index=$(($index+1))
+        done
+        curl -sfg --compressed -C 0 ${urlreq[@]} \
             | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g'
     fi
 }

--- a/pacaur
+++ b/pacaur
@@ -1297,7 +1297,7 @@ DownloadJson() {
 }
 
 GetJson() {
-    if json_verify -q  <<< "$2"; then
+    if json_verify -q <<< "$2"; then
         case "$1" in
             var)
                 json_reformat <<< "$2" | tr -d "\", " | grep -Po "$3:.*" | sed -r "s/$3:/$3#/g" | awk -F "#" '{print $2}';;


### PR DESCRIPTION
…s than 8125 chars

Divides the request into requests at most 8000 characters long, allowing the request to be successful.
Modifies the DownloadJson() function of pacaur.

Potentially addresses  #209,#238 , #504 
<del>
~~
Do note that while this fixes the bug in pacaur, it appears that the YAJL tools (json_verify, json_reformat) have a maximum allowed json character limit of 2^18=262144, and so if the rpc return is larger than this limit, json_verify and json_reformat fail causing pacaur to fail. Although as I have not communicated with the devs it is possible that I just happen to have errors around that location in the files I test. Due to this I cannot completely test the pacaur to successful completion, however in my tests this fixed DownloadJson().
~~
</del>
It appears that my error was caused by the use of sed, and was fixed by running sed twice. 