### PR TITLE
Add native formatting of AUR info search

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1161,6 +1161,9 @@ SearchAur() {
 }
 
 InfoAur() {
+    local formatopts formatstrings formattab formattedinfo installedpkgs cowerarray repositoryformat 
+    local cowerinfo i info infotitle outofdate linfo lmulti installedversion lastversion installedtag singleinfo multiinfo maxlength 
+
     if [[ -z "$(grep -E "\-\-[r]?sort" <<< ${coweropts[@]})" ]]; then
         [[ $sortorder = descending ]] && coweropts+=("--rsort=$sortby") || coweropts+=("--sort=$sortby");
     fi

--- a/pacaur
+++ b/pacaur
@@ -1164,6 +1164,9 @@ SearchInfoAur() {
 
     formatstrings=( $"Name" $"Version" $"Description" $"URL" $"AUR Page" $"Licenses" $"Provides" $"Depends on" $"Make Deps" $"Optional Deps" $"Conflicts With" $"Replaces" $"Mantainer" $"Votes" $"Popularity" $"Out of Date" $"Submitted" $"Last Modified" ) 
     
+    # get a list of the query packages to check if they are installed
+    readarray installedpkgs < <(expac -Qs '%n' $@)
+    
     # in some languages more tabs are needed to properly adjust the info
     formattab=16
     for string in "${formatstrings[@]}"
@@ -1200,6 +1203,12 @@ SearchInfoAur() {
             # alignment of new lines of multiline info 
             lmulti="\x1b[$(( $formattab + 2 ))C"
             
+            # format name of the pkg with installed flag
+            if [ $i -eq 0 ]; then
+                if ($(echo $installedpkgs | grep -Fxq $info)); then
+                    info+=" ["$"installed""]"
+                fi
+            fi
             # format lists
             if [ $i -eq 5 ] || [ $i -eq 6 ] || [ $i -eq 7 ] || [ $i -eq 8 ] || [ $i -eq 10 ] || [ $i -eq 11 ]; then
                 # introduce line breaks if needed and align the text

--- a/pacaur
+++ b/pacaur
@@ -1217,11 +1217,11 @@ InfoAur() {
             # alignment of new lines of multiline info 
             lmulti="\x1b[$(( $formattab + 2 ))C"
             
-            # format name of the pkg with installed flag, including version check
-            if [ $i -eq 0 ]; then
+            case $i in
+              0)# format name of the pkg with installed flag, including version check
                 if ($(echo $installedpkgs | grep -Fq $info)); then
-                    installedversion=$(tr -dc '[[:print:]]' <<< ${cowerinfo[1]})
-                    lastversion="$(echo "$installedpkgs" | awk -v var="$info" '$1 == var {print $2}')"
+                    lastversion=$(tr -dc '[[:print:]]' <<< ${cowerinfo[1]})
+                    installedversion="$(echo "$installedpkgs" | awk -v var="$info" '$1 == var {print $2}')"
                     if [[ "$lastversion" == "$installedversion" ]]; then
                         installedtag="${colorG}"$"installed"
                     else
@@ -1231,18 +1231,23 @@ InfoAur() {
                 else
                     info="${colorW}$info"
                 fi
-            # format version
-            elif [ $i -eq 1 ]; then
+              ;;
+              1)# format version
                 if $outofdate; then
                     info="${colorR}$info${reset}"
                 else
                     info="${colorG}$info${reset}"
                 fi
-            # format URLs
-            elif [ $i -eq 3 ] || [ $i -eq 4 ]; then
+              ;;
+              3|4)# format URLs
                 info="${colorC}$info${reset}"
-            # format optional dependencies
-            elif [ $i -eq 9 ]; then
+              ;;
+              2|5|6|7|8|10|11)# format description and lists
+                # introduce line breaks if needed and align the text
+                maxlength=$(( $(tput cols) - $formattab ))
+                info=$(echo $info | sed 's/#/  /g' | fold -s -w $(( $maxlength - 2 )) | sed "s/^ //;2,$ s/^/$lmulti/")
+              ;;
+              9)# format optional dependencies
                 # remove last separator (#)
                 info=$(echo $info | rev | sed 's/#//' | rev)
                 # store pkgs into an array
@@ -1255,23 +1260,19 @@ InfoAur() {
                 for singleinfo in "${multiinfo[@]:1}"; do
                     info+="\n$(echo "$singleinfo" | tr -dc '[[:print:]]' | fold -s -w $(( $maxlength - 2)) | sed "s/^ //;s/^/$lmulti/")"
                 done
-            # format out of date
-            elif [ $i -eq 15 ]; then
+              ;;
+              15)# format out of date
                 info=$(echo "${info^}")
                 if $outofdate; then
                     info="${colorR}"$"Yes""${reset}"
                 else
                     info="${colorG}"$"No""${reset}"
                 fi
-            # format dates
-            elif [ $i -eq 16 ] || [ $i -eq 17 ]; then
+              ;;
+              16|17)# format dates
                 info=$(date -d @${cowerinfo[$i]})
-            # format description and lists
-            elif [ $i -eq 2 ] || [ $i -eq 5 ] || [ $i -eq 6 ] || [ $i -eq 7 ] || [ $i -eq 8 ] || [ $i -eq 10 ] || [ $i -eq 11 ]; then
-                # introduce line breaks if needed and align the text
-                maxlength=$(( $(tput cols) - $formattab ))
-                info=$(echo $info | sed 's/#/  /g' | fold -s -w $(( $maxlength - 2 )) | sed "s/^ //;2,$ s/^/$lmulti/") 
-            fi
+              ;;
+            esac
             
             # store formatted text
             formattedinfo+=("${colorW}${infotitle}${linfo}:${reset} ${info}\n") 
@@ -1835,7 +1836,6 @@ case $operation in
                         Note "w" $"Package ${colorW}${aurpkgs[*]}${reset} not found in repositories, trying ${colorM}AUR${reset}..."
                     fi
                 fi
-                SearchInfoAur ${aurpkgs[@]}
                 InfoAur ${aurpkgs[@]}
             fi
         # clean (-Sc) handling

--- a/pacaur
+++ b/pacaur
@@ -1152,7 +1152,15 @@ MakePkgs() {
     [[ -z "${errmakepkg[@]}" ]] && exit
 }
 
-SearchInfoAur() {
+SearchAur() {
+    if [[ -z "$(grep -E "\-\-[r]?sort" <<< ${coweropts[@]})" ]]; then
+        [[ $sortorder = descending ]] && coweropts+=("--rsort=$sortby") || coweropts+=("--sort=$sortby");
+    fi
+
+    cower ${coweropts[@]} -- $@
+}
+
+InfoAur() {
     if [[ -z "$(grep -E "\-\-[r]?sort" <<< ${coweropts[@]})" ]]; then
         [[ $sortorder = descending ]] && coweropts+=("--rsort=$sortby") || coweropts+=("--sort=$sortby");
     fi
@@ -1167,27 +1175,30 @@ SearchInfoAur() {
     # get a list of the query packages to check if they are installed
     readarray installedpkgs < <(expac -Qs '%n' $@)
     
-    # in some languages more tabs are needed to properly adjust the info
-    formattab=16
+    # get the longest title to adjust the text
+    formattab=1
     for string in "${formatstrings[@]}"
     do
         lstring=$(GetLength "$string")
-        if (( $lstring > 16 )); then
-            formattab=26
-        fi
+        if (( $lstring > $formattab )); then formattab=$lstring; fi
     done
+    formattab=$(( $formattab + 1 ))
 
-    # print each package info individually
+    # store all formatted text in an array
+    formattedinfo=()
+
+    # format each package info individually
     for rows in "${cowerarray[@]}"
     do
         # array of info for the current package
         readarray cowerinfo < <(echo $rows | tr '|' '\n')
         
         # repository info is not included in cower information
-        printf "${colorW}%-${formattab}s${reset}: ${colorM}%s${reset}\n" $"Repository" "aur"
+        printf -v repositoryformat "${colorW}%-${formattab}s:${reset} ${colorM}%s${reset}\n" $"Repository" "aur"
+        formattedinfo+=("$repositoryformat")
 
         # check if the package is out of date
-        if [[ "${cowerinfo[15]}" == "yes" ]]; then outofdate=true; fi
+        if [[ $(echo "${cowerinfo[15]}") == "yes" ]]; then outofdate=true; else outofdate=false; fi
 
         for (( i=0; i < "${#formatstrings[@]}"; ++i ))
         do
@@ -1227,8 +1238,16 @@ SearchInfoAur() {
             elif [ $i -eq 9 ]; then
                 # remove last separator (#)
                 info=$(echo $info | rev | sed 's/#//' | rev)
-                # set tabs for new lines with an escape character
-                info=$(echo $info | sed "s/\#/\n$lmulti/g")
+                # store pkgs into an array
+                readarray multiinfo < <(echo $info | sed "s/\#/\n/g")
+                # introduce line breaks if needed and align the text
+                maxlength=$(( $(tput cols) - $formattab ))
+                # format first optional pkg
+                info="$(echo "${multiinfo[0]}" | tr -dc '[[:print:]]' | fold -s -w $(( $maxlength - 2)) | sed "s/^ //;2,$ s/^/$lmulti/")"
+                # from second optional pkg all pkgs have the same format
+                for singleinfo in "${multiinfo[@]:1}"; do
+                    info+="\n$(echo "$singleinfo" | tr -dc '[[:print:]]' | fold -s -w $(( $maxlength - 2)) | sed "s/^ //;s/^/$lmulti/")"
+                done
             # format out of date
             elif [ $i -eq 15 ]; then
                 info=$(echo "${info^}")
@@ -1244,14 +1263,19 @@ SearchInfoAur() {
             elif [ $i -eq 2 ] || [ $i -eq 5 ] || [ $i -eq 6 ] || [ $i -eq 7 ] || [ $i -eq 8 ] || [ $i -eq 10 ] || [ $i -eq 11 ]; then
                 # introduce line breaks if needed and align the text
                 maxlength=$(( $(tput cols) - $formattab ))
-                info=$(echo $info | sed 's/#/  /g' | fold -s -w $(( $maxlength - 2 )) | sed "2,$ s/^/$lmulti/") 
+                info=$(echo $info | sed 's/#/  /g' | fold -s -w $(( $maxlength - 2 )) | sed "s/^ //;2,$ s/^/$lmulti/") 
             fi
             
-            echo -ne "${colorW}${infotitle}${reset}"
-            echo -ne "${linfo}: ${info}\n" 
+            # store formatted text
+            formattedinfo+=("${colorW}${infotitle}${linfo}:${reset} ${info}\n") 
         done
-        echo
+    
+        # add a line break between pkgs
+        formattedinfo+=("\n")
     done
+
+    # print formatted info from all packages
+    local IFS=''; echo -ne "${formattedinfo[*]}"
 }
 
 CheckUpdates() {
@@ -1783,7 +1807,7 @@ case $operation in
                 [[ $refresh ]] && sudo $pacmanbin ${pacmanarg[@]} ${pacopts[@]} ${ignoreopts[@]} -- ${pkgs[@]}
                 [[ ! $refresh ]] && $pacmanbin ${pacmanarg[@]} ${pacopts[@]} ${ignoreopts[@]} -- ${pkgs[@]}
             fi
-            [[ ! $repo ]] && [[ $fallback = true || $aur ]] && SearchInfoAur ${pkgs[@]}
+            [[ ! $repo ]] && [[ $fallback = true || $aur ]] && SearchAur ${pkgs[@]}
         # info (-Si, -i) handling
         elif [[ $info ]]; then
             if [[ -z "${pkgs[@]}" ]]; then
@@ -1805,6 +1829,7 @@ case $operation in
                     fi
                 fi
                 SearchInfoAur ${aurpkgs[@]}
+                InfoAur ${aurpkgs[@]}
             fi
         # clean (-Sc) handling
         elif [[ $cleancache ]]; then

--- a/pacaur
+++ b/pacaur
@@ -1173,7 +1173,7 @@ InfoAur() {
     formatstrings=( $"Name" $"Version" $"Description" $"URL" $"AUR Page" $"Licenses" $"Provides" $"Depends on" $"Make Deps" $"Optional Deps" $"Conflicts With" $"Replaces" $"Mantainer" $"Votes" $"Popularity" $"Out of Date" $"Submitted" $"Last Modified" ) 
     
     # get a list of the query packages to check if they are installed
-    readarray installedpkgs < <(expac -Qs '%n' $@)
+    installedpkgs="$(expac -Q '%n %v' $@)"
     
     # get the longest title to adjust the text
     formattab=1
@@ -1217,10 +1217,17 @@ InfoAur() {
             # alignment of new lines of multiline info 
             lmulti="\x1b[$(( $formattab + 2 ))C"
             
-            # format name of the pkg with installed flag
+            # format name of the pkg with installed flag, including version check
             if [ $i -eq 0 ]; then
-                if ($(echo $installedpkgs | grep -Fxq $info)); then
-                    info="${colorW}$info ${colorC}[${colorG}"$"installed""${colorC}]${reset}"
+                if ($(echo $installedpkgs | grep -Fq $info)); then
+                    installedversion=$(tr -dc '[[:print:]]' <<< ${cowerinfo[1]})
+                    lastversion="$(echo "$installedpkgs" | awk -v var="$info" '$1 == var {print $2}')"
+                    if [[ "$lastversion" == "$installedversion" ]]; then
+                        installedtag="${colorG}"$"installed"
+                    else
+                        installedtag="${colorR}"$"installed"": $installedversion"
+                    fi
+                    info="${colorW}$info ${colorC}[${installedtag}${colorC}]${reset}"
                 else
                     info="${colorW}$info"
                 fi

--- a/pacaur
+++ b/pacaur
@@ -1156,7 +1156,74 @@ SearchInfoAur() {
     if [[ -z "$(grep -E "\-\-[r]?sort" <<< ${coweropts[@]})" ]]; then
         [[ $sortorder = descending ]] && coweropts+=("--rsort=$sortby") || coweropts+=("--sort=$sortby");
     fi
-    cower ${coweropts[@]} -- $@
+    
+    # store cower information into an array, one line per package and values 
+    # separated by vertical slashes
+    formatopts='--listdelim # --format %n|%v|%d|%u|%p|%L|%P|%D|%M|%O|%C|%R|%m|%o|%r|%t|%s|%a\n'
+    readarray cowerarray < <(cower ${formatopts} ${coweropts[@]} -- $@)
+
+    formatstrings=( $"Name" $"Version" $"Description" $"URL" $"AUR Page" $"Licenses" $"Provides" $"Depends on" $"Make Deps" $"Optional Deps" $"Conflicts With" $"Replaces" $"Mantainer" $"Votes" $"Popularity" $"Out of Date" $"Submitted" $"Last Modified" ) 
+    
+    # in some languages more tabs are needed to properly adjust the info
+    formattab=16
+    for string in "${formatstrings[@]}"
+    do
+        lstring=$(GetLength "$string")
+        if (( $lstring > 16 )); then
+            formattab=26
+        fi
+    done
+
+    # print each package info individually
+    for rows in "${cowerarray[@]}"
+    do
+        # array of info for the current package
+        readarray cowerinfo < <(echo $rows | tr '|' '\n')
+        
+        # repository info is not included in cower information
+        printf "${colorW}%-${formattab}s${reset}: %s\n" $"Repository" "aur"
+
+        for (( i=0; i < "${#formatstrings[@]}"; ++i ))
+        do
+            infotitle=${formatstrings[$i]}
+            
+            # remove non-printable characters from info
+            info=${cowerinfo[$i]}
+            info=$(tr -dc '[[:print:]]' <<< "$info")
+            
+            # replace empty info with 'None' to fit pacman print format
+            if [[ ! $info ]]; then info=$"None"; fi
+
+            # alignment of first line info
+            linfotitle=$(GetLength "$infotitle")
+            linfo="\x1b[$(( $formattab - $linfotitle ))C"
+            # alignment of new lines of multiline info 
+            lmulti="\x1b[$(( $formattab + 2 ))C"
+            
+            # format lists
+            if [ $i -eq 5 ] || [ $i -eq 6 ] || [ $i -eq 7 ] || [ $i -eq 8 ] || [ $i -eq 10 ] || [ $i -eq 11 ]; then
+                # introduce line breaks if needed and align the text
+                maxlength=$(( $(tput cols) - $formattab ))
+                info=$(echo $info | sed 's/#/  /g' | fold -s -w $(( $maxlength - 2 )) | sed "2,$ s/^/$lmulti/") 
+            # format optional dependencies
+            elif [ $i -eq 9 ]; then
+                # remove last separator (#)
+                info=$(echo $info | rev | sed 's/#//' | rev)
+                # set tabs for new lines with an escape character
+                info=$(echo $info | sed "s/\#/\n$lmulti/g")
+            # format out of date
+            elif [ $i -eq 15 ]; then
+                info=$(echo "${info^}")
+            # format dates
+            elif [ $i -eq 16 ] || [ $i -eq 17 ]; then
+                info=$(date -d @${cowerinfo[$i]})
+            fi
+            
+            echo -ne "${colorW}${infotitle}${reset}"
+            echo -ne "${linfo}: ${info}\n" 
+        done
+        echo
+    done
 }
 
 CheckUpdates() {
@@ -1222,6 +1289,7 @@ CheckUpdates() {
             lArepo=3
         fi
     fi
+
 
     if [[ ! $aur ]]; then
         repopkgsQood=($($pacmanbin -Quq $@))

--- a/pacaur
+++ b/pacaur
@@ -1184,7 +1184,10 @@ SearchInfoAur() {
         readarray cowerinfo < <(echo $rows | tr '|' '\n')
         
         # repository info is not included in cower information
-        printf "${colorW}%-${formattab}s${reset}: %s\n" $"Repository" "aur"
+        printf "${colorW}%-${formattab}s${reset}: ${colorM}%s${reset}\n" $"Repository" "aur"
+
+        # check if the package is out of date
+        if [[ "${cowerinfo[15]}" == "yes" ]]; then outofdate=true; fi
 
         for (( i=0; i < "${#formatstrings[@]}"; ++i ))
         do
@@ -1206,14 +1209,20 @@ SearchInfoAur() {
             # format name of the pkg with installed flag
             if [ $i -eq 0 ]; then
                 if ($(echo $installedpkgs | grep -Fxq $info)); then
-                    info+=" ["$"installed""]"
+                    info="${colorW}$info ${colorC}[${colorG}"$"installed""${colorC}]${reset}"
+                else
+                    info="${colorW}$info"
                 fi
-            fi
-            # format lists
-            if [ $i -eq 5 ] || [ $i -eq 6 ] || [ $i -eq 7 ] || [ $i -eq 8 ] || [ $i -eq 10 ] || [ $i -eq 11 ]; then
-                # introduce line breaks if needed and align the text
-                maxlength=$(( $(tput cols) - $formattab ))
-                info=$(echo $info | sed 's/#/  /g' | fold -s -w $(( $maxlength - 2 )) | sed "2,$ s/^/$lmulti/") 
+            # format version
+            elif [ $i -eq 1 ]; then
+                if $outofdate; then
+                    info="${colorR}$info${reset}"
+                else
+                    info="${colorG}$info${reset}"
+                fi
+            # format URLs
+            elif [ $i -eq 3 ] || [ $i -eq 4 ]; then
+                info="${colorC}$info${reset}"
             # format optional dependencies
             elif [ $i -eq 9 ]; then
                 # remove last separator (#)
@@ -1223,9 +1232,19 @@ SearchInfoAur() {
             # format out of date
             elif [ $i -eq 15 ]; then
                 info=$(echo "${info^}")
+                if $outofdate; then
+                    info="${colorR}"$"Yes""${reset}"
+                else
+                    info="${colorG}"$"No""${reset}"
+                fi
             # format dates
             elif [ $i -eq 16 ] || [ $i -eq 17 ]; then
                 info=$(date -d @${cowerinfo[$i]})
+            # format description and lists
+            elif [ $i -eq 2 ] || [ $i -eq 5 ] || [ $i -eq 6 ] || [ $i -eq 7 ] || [ $i -eq 8 ] || [ $i -eq 10 ] || [ $i -eq 11 ]; then
+                # introduce line breaks if needed and align the text
+                maxlength=$(( $(tput cols) - $formattab ))
+                info=$(echo $info | sed 's/#/  /g' | fold -s -w $(( $maxlength - 2 )) | sed "2,$ s/^/$lmulti/") 
             fi
             
             echo -ne "${colorW}${infotitle}${reset}"
@@ -1708,6 +1727,7 @@ if [[ -n "$(grep '^Color' '/etc/pacman.conf')" && $color != 'never' ]]; then
     colorY="\e[1;33m"
     colorB="\e[1;34m"
     colorM="\e[1;35m"
+    colorC="\e[1;36m"
     colorW="\e[1;39m"
 elif [[ -z "$(grep '^Color' '/etc/pacman.conf')" && ($color = 'always' || $color = 'auto') ]]; then
     pacopts+=("--color $color") && coweropts+=("--color=$color")
@@ -1717,6 +1737,7 @@ elif [[ -z "$(grep '^Color' '/etc/pacman.conf')" && ($color = 'always' || $color
     colorY="\e[1;33m"
     colorB="\e[1;34m"
     colorM="\e[1;35m"
+    colorC="\e[1;36m"
     colorW="\e[1;39m"
 else
     [[ $color != 'always' && $color != 'auto' ]] && makeopts+=("--nocolor")

--- a/po/es.po
+++ b/po/es.po
@@ -11,25 +11,25 @@ msgstr ""
 msgid "${colorW}Starting AUR upgrade...${reset}"
 msgstr "${colorW}Iniciando actualización de AUR...${reset}"
 
-#: pacaur:129
+#: pacaur:134
 msgid "${colorW}$i${reset} is ${colorY}not present${reset} in AUR -- skipping"
 msgstr "${colorW}$i${reset} ${colorY}no existe${reset} en AUR -- omitiendo"
 
-#: pacaur:159 pacaur:215 pacaur:1139
+#: pacaur:165 pacaur:209 pacaur:1209
 msgid "latest"
 msgstr "último"
 
-#: pacaur:164
+#: pacaur:170
 msgid "${checkaurpkgs[$i]} is in IgnorePkg/IgnoreGroup. Install anyway?"
 msgstr ""
 "${checkaurpkgs[$i]} está en IgnorePkg/IgnoreGroup. ¿Instalar de todos modos?"
 
-#: pacaur:165
+#: pacaur:171
 msgid "${colorW}${checkaurpkgs[$i]}${reset}: ignoring package upgrade"
 msgstr ""
 "${colorW}${checkaurpkgs[$i]}${reset}: ignorando la actualización del paquete"
 
-#: pacaur:170
+#: pacaur:176
 msgid ""
 "${colorW}${checkaurpkgs[$i]}${reset}: ignoring package upgrade "
 "(${colorR}${checkaurpkgsQver[$i]}${reset} => "
@@ -39,33 +39,33 @@ msgstr ""
 "(${colorR}${checkaurpkgsQver[$i]}${reset} => "
 "${colorG}${checkaurpkgsAver[$i]}${reset})"
 
-#: pacaur:184
+#: pacaur:190
 msgid "resolving dependencies..."
 msgstr "resolviendo dependencias..."
 
-#: pacaur:220
+#: pacaur:214
 msgid "no results found for $i"
 msgstr "no se encontraron resultados para $i"
 
-#: pacaur:358
+#: pacaur:369
 msgid "dependency cycle detected"
 msgstr "bucle de dependencias detectado"
 
-#: pacaur:426 pacaur:441
+#: pacaur:437 pacaur:452
 msgid "${colorW}$i${reset}: ignoring package upgrade"
 msgstr "${colorW}$i${reset}: ignorando actualización del paquete"
 
-#: pacaur:427 pacaur:433 pacaur:438 pacaur:442
+#: pacaur:438 pacaur:444 pacaur:449 pacaur:453
 msgid "Unresolved dependency '${colorW}$i${reset}'"
 msgstr "Dependencia sin resolver '${colorW}$i${reset}'"
 
-#: pacaur:437
+#: pacaur:448
 msgid "$i dependency is in IgnorePkg/IgnoreGroup. Install anyway?"
 msgstr ""
 "La dependencia $i se encuentra en IgnorePkg/IgnoreGroup. ¿Instalar de todos "
 "modos?"
 
-#: pacaur:470
+#: pacaur:488
 msgid ""
 "${colorW}There are ${#providers[@]} providers available for "
 "${providersdeps[$i]}:${reset}"
@@ -73,44 +73,44 @@ msgstr ""
 "${colorW}Existen ${#providers[@]} proveedores disponibles para "
 "${providersdeps[$i]}:${reset}"
 
-#: pacaur:477
+#: pacaur:495
 msgid "Enter a number (default=0):"
 msgstr "Ingrese un número (por defecto=0):"
 
-#: pacaur:484
+#: pacaur:502
 msgid "invalid value: $nb is not between 0 and $providersnb"
 msgstr "valor inválido: $nb no está entre 0 y $providersnb"
 
-#: pacaur:489
+#: pacaur:507
 msgid "invalid number: $nb"
 msgstr "número inválido: $nb"
 
-#: pacaur:531
+#: pacaur:549
 msgid "looking for inter-conflicts..."
 msgstr "verificando conflictos..."
 
-#: pacaur:567 pacaur:636
+#: pacaur:585 pacaur:654
 msgid "$j and $k are in conflict ($i). Remove $k?"
 msgstr "$j y $k están en conflicto ($i). ¿Eliminar $k?"
 
-#: pacaur:581 pacaur:644
+#: pacaur:599 pacaur:662
 msgid "unresolvable package conflicts detected"
 msgstr "se han detectado paquetes con conflictos no resolubles"
 
-#: pacaur:582 pacaur:645
+#: pacaur:600 pacaur:663
 msgid "failed to prepare transaction (conflicting dependencies)"
 msgstr "error al preparar transacción (dependencias en conflicto)"
 
-#: pacaur:583 pacaur:646
+#: pacaur:601 pacaur:664
 #, fuzzy
 msgid "$j and $k are in conflict"
 msgstr "$j y $k están en conflicto"
 
-#: pacaur:664
+#: pacaur:682
 msgid "${colorW}${depsAname[$i]}${reset} latest revision -- fetching"
 msgstr "${colorW}${depsAname[$i]}${reset} última revisión -- trayendo"
 
-#: pacaur:667
+#: pacaur:685
 msgid ""
 "${colorW}${depsAname[$i]}-${depsQver[$i]}${reset} is up to date -- "
 "reinstalling"
@@ -118,14 +118,14 @@ msgstr ""
 "${colorW}${depsAname[$i]}-${depsQver[$i]}${reset} está actualizado -- re-"
 "instalando"
 
-#: pacaur:669
+#: pacaur:687
 msgid ""
 "${colorW}${depsAname[$i]}-${depsQver[$i]}${reset} is up to date -- skipping"
 msgstr ""
 "${colorW}${depsAname[$i]}-${depsQver[$i]}${reset} está actualizado -- "
 "omitiendo"
 
-#: pacaur:684
+#: pacaur:702
 msgid ""
 "${colorW}${depsAname[$i]}-${depsAver[$i]}${reset} has been flagged ${colorR}"
 "out of date${reset} on ${colorY}$(date -d \"@${depsAood[$i]}\" \"+%Y-%m-%d"
@@ -135,154 +135,152 @@ msgstr ""
 "${colorR}out of date${reset} el ${colorY}$(date -d \"@${depsAood[$i]}\" \"+"
 "%Y-%m-%d\")${reset}"
 
-#: pacaur:712
+#: pacaur:730
 msgid "(cached)"
 msgstr "(en caché)"
 
-#: pacaur:716 pacaur:738
-msgid "Name"
-msgstr "Nombre"
+#: pacaur:735 pacaur:768
+#, fuzzy
+msgid "AUR Packages  (${#deps[@]})"
+msgstr "Paquetes de AUR (${#deps[@]}):"
 
-#: pacaur:716 pacaur:738
+#: pacaur:735 pacaur:769
+#, fuzzy
+msgid "Repo Packages (${#repodepspkgs[@]})"
+msgstr "Paquetes (${#repodepspkgs[@]}):"
+
+#: pacaur:735
 msgid "Old Version"
 msgstr "Versión Antigua"
 
-#: pacaur:716 pacaur:738
+#: pacaur:735
 msgid "New Version"
 msgstr "Versión Nueva"
 
-#: pacaur:716 pacaur:738
+#: pacaur:735
 msgid "Download Size"
 msgstr "Tamaño de Descarga"
 
-#: pacaur:727 pacaur:751
-msgid "AUR Packages  (${#deps[@]}):"
-msgstr "Paquetes de AUR (${#deps[@]}):"
-
-#: pacaur:737 pacaur:752
-msgid "Repo Packages (${#repodepspkgs[@]}):"
-msgstr "Paquetes (${#repodepspkgs[@]}):"
-
-#: pacaur:740
+#: pacaur:757
 msgid "${binarysize[$i]} MiB"
 msgstr "${binarysize[$i]} MiB"
 
-#: pacaur:756
+#: pacaur:773
 msgid "Repo Download Size:"
 msgstr "Tamaño de la Descarga del Repositorio:"
 
-#: pacaur:756
+#: pacaur:773
 msgid "Repo Installed Size:"
 msgstr "Tamaño de la Instalación del Repositorio:"
 
-#: pacaur:756
+#: pacaur:773
 msgid "$sumk MiB"
 msgstr "$sumk MiB"
 
-#: pacaur:756
+#: pacaur:773
 msgid "$summ MiB"
 msgstr "$summ MiB"
 
-#: pacaur:765
+#: pacaur:782 pacaur:876
 msgid "installation"
 msgstr "la instalación"
 
-#: pacaur:765
+#: pacaur:782 pacaur:876
 msgid "download"
 msgstr "la descarga"
 
-#: pacaur:766
+#: pacaur:783 pacaur:877
 msgid "Proceed with $action?"
 msgstr "¿Continuar con $action?"
 
-#: pacaur:775
+#: pacaur:792
 msgid "${colorW}Retrieving package(s)...${reset}"
 msgstr "${colorW}Obteniendo paquete(s)...${reset}"
 
-#: pacaur:811
+#: pacaur:825
 msgid "View $i build files diff?"
 msgstr "¿Ver las diferencias de $i (build files)?"
 
-#: pacaur:813
+#: pacaur:827
 #, fuzzy
 msgid "${colorW}$i${reset} build files diff viewed"
 msgstr "vistas las diferencias (build files) ${colorW}$j${reset}"
 
-#: pacaur:816
+#: pacaur:831
 #, fuzzy
 msgid "${colorW}$i${reset} build files are up-to-date -- skipping"
 msgstr "${colorW}$i${reset} está actualizado -- omitiendo"
 
-#: pacaur:820
+#: pacaur:835
 msgid "View $i PKGBUILD?"
 msgstr "¿Ver el PKGBUILD de $i?"
 
-#: pacaur:822 pacaur:844
+#: pacaur:837 pacaur:859
 msgid "${colorW}$i${reset} PKGBUILD viewed"
 msgstr "PKGBUILD de ${colorW}$i${reset} visto"
 
-#: pacaur:824 pacaur:846
+#: pacaur:839 pacaur:861
 msgid "Could not open ${colorW}$i${reset} PKGBUILD"
 msgstr "No se pudo abrir el PKGBUILD de ${colorW}$i${reset}"
 
-#: pacaur:830
+#: pacaur:845
 msgid "View $j script?"
 msgstr "¿Ver el script $j?"
 
-#: pacaur:832 pacaur:851
+#: pacaur:847 pacaur:866
 msgid "${colorW}$j${reset} script viewed"
 msgstr "visto el script ${colorW}$j${reset}"
 
-#: pacaur:834 pacaur:853
+#: pacaur:849 pacaur:868
 msgid "Could not open ${colorW}$j${reset} script"
 msgstr "No se pudo abrir el script ${colorW}$j${reset}"
 
-#: pacaur:915
+#: pacaur:938
 #, fuzzy
 msgid "Checking ${colorW}${pkgsdeps[$i]}${reset} integrity..."
 msgstr "Instalando las dependencias de ${colorW}${pkgsdeps[$i]}${reset}..."
 
-#: pacaur:927
+#: pacaur:950
 #, fuzzy
 msgid "failed to verify ${colorW}$i${reset} integrity"
 msgstr "No se pudo abrir el script ${colorW}$j${reset}"
 
-#: pacaur:932
+#: pacaur:955
 msgid "build.lck exists in $tmpdir"
 msgstr "build.lck existe en $tmpdir"
 
-#: pacaur:937
+#: pacaur:960
 #, fuzzy
 msgid ""
 "Installing ${colorW}${repoprovidersconflictingpkgs[@]}${reset} "
 "dependencies..."
 msgstr "Instalando las dependencias de ${colorW}${providerpkgs[@]}${reset}..."
 
-#: pacaur:961
+#: pacaur:984
 #, fuzzy
 msgid "${colorW}$j${reset} is up-to-date -- skipping"
 msgstr ""
 "${colorW}${depsAname[$i]}-${depsQver[$i]}${reset} está actualizado -- "
 "omitiendo"
 
-#: pacaur:981
+#: pacaur:1005
 msgid "Installing ${colorW}$j${reset} cached package..."
 msgstr "Instalando ${colorW}$j${reset} desde la caché..."
 
-#: pacaur:985
+#: pacaur:1009
 msgid "Package ${colorW}$j${reset} already available in cache"
 msgstr "El paquete ${colorW}$j${reset} ya está disponible en la caché"
 
-#: pacaur:994
+#: pacaur:1018
 msgid "Building ${colorW}${pkgsdeps[$i]}${reset} package(s)..."
 msgstr "Construyendo paquete(s) ${colorW}${pkgsdeps[$i]}${reset}..."
 
-#: pacaur:1029
+#: pacaur:1054
 #, fuzzy
 msgid "Installing ${colorW}${pkgsdeps[$i]}${reset} package(s)..."
 msgstr "Construyendo paquete(s) ${colorW}${pkgsdeps[$i]}${reset}..."
 
-#: pacaur:1031
+#: pacaur:1056
 msgid ""
 "${colorW}${pkgsdeps[$i]}${reset} package(s) failed to install. Check ."
 "SRCINFO for mismatching data with PKGBUILD."
@@ -290,143 +288,227 @@ msgstr ""
 "${colorW}${pkgsdeps[$i]}${reset} no se instaló/instalaron correctamente."
 "Comprueba la disparidad de datos de SRCINFO con PKGBUILD."
 
-#: pacaur:1049
+#: pacaur:1074
 msgid "Removing installed AUR dependencies..."
 msgstr "Quitando las dependencias instaladas desde AUR..."
 
-#: pacaur:1065
+#: pacaur:1090
 msgid "${colorW}$i${reset} is a ${colorY}new orphan${reset} package"
 msgstr "${colorW}$i${reset} es un ${colorY}nuevo paquete huérfano${reset}"
 
-#: pacaur:1070
+#: pacaur:1095
 #, fuzzy
 msgid "failed to build ${colorW}$i${reset} package(s)"
 msgstr "Construyendo paquete(s) ${colorW}${pkgsdeps[$i]}${reset}..."
 
-#: pacaur:1097 pacaur:1138
+#: pacaur:1117
+msgid "Repository"
+msgstr "Repositorio"
+
+#: pacaur:1118
+msgid "Name"
+msgstr "Nombre"
+
+#: pacaur:1119
+msgid "Version"
+msgstr "Versión"
+
+#: pacaur:1120
+msgid "Description"
+msgstr "Descripción"
+
+#: pacaur:1121
+msgid "URL"
+msgstr "URL"
+
+#: pacaur:1122
+msgid "AUR Page"
+msgstr "Página AUR"
+
+#: pacaur:1123
+msgid "Licenses"
+msgstr "Licencias"
+
+#: pacaur:1124
+msgid "Provides"
+msgstr "Provee"
+
+#: pacaur:1125
+msgid "Depends on"
+msgstr "Depende de"
+
+#: pacaur:1126
+msgid "Make Deps"
+msgstr "Dependencias Make"
+
+#: pacaur:1127
+msgid "Optional Deps"
+msgstr "Dependencias opcionales"
+
+#: pacaur:1128
+msgid "Conflicts With"
+msgstr "En conflicto con"
+
+#: pacaur:1129
+msgid "Replaces"
+msgstr "Reemplaza a"
+
+#: pacaur:1130
+msgid "Mantainer"
+msgstr "Encargado"
+
+#: pacaur:1131
+msgid "Votes"
+msgstr "Votos"
+
+#: pacaur:1132
+msgid "Popularity"
+msgstr "Popularidad"
+
+#: pacaur:1133
+msgid "Out of Date"
+msgstr "Obsoleto"
+
+#: pacaur:1134
+msgid "Submitted"
+msgstr "Creado"
+
+#: pacaur:1135
+msgid "Last Modified"
+msgstr "Última modificación"
+
+#: pacaur:1149
+msgid "None"
+msgstr "Nada"
+
+#: pacaur:1167 pacaur:1208
 msgid "[ ignored ]"
 msgstr "[ ignorado ]"
 
-#: pacaur:1153
+#: pacaur:1225
 msgid "Packages to keep:"
 msgstr "Paquetes a mantener:"
 
-#: pacaur:1153
+#: pacaur:1225
 msgid "All locally installed packages"
 msgstr "Todos los paquetes instalados localmente"
 
-#: pacaur:1154
+#: pacaur:1226
 msgid "AUR cache directory:"
 msgstr "Directorio de la caché de AUR:"
 
-#: pacaur:1156
+#: pacaur:1228
 msgid "Do you want to remove all other packages from AUR cache?"
 msgstr "¿Desea quitar todos los otros paquetes de la caché de AUR?"
 
-#: pacaur:1157
+#: pacaur:1229
 msgid "removing old packages from cache..."
 msgstr "quitando los paquetes viejos de la caché..."
 
-#: pacaur:1161
+#: pacaur:1234
 msgid "Do you want to remove ALL files from AUR cache?"
 msgstr "¿Desea eliminar TODOS los archivos de la caché de AUR?"
 
-#: pacaur:1162
+#: pacaur:1235
 msgid "removing all files from AUR cache..."
 msgstr "eliminando todos los archivos de la caché de AUR..."
 
-#: pacaur:1168
+#: pacaur:1241
 #, fuzzy
 msgid "Sources to keep:"
 msgstr "Paquetes a mantener:"
 
-#: pacaur:1168
+#: pacaur:1241
 msgid "All development packages sources"
 msgstr "Todos los archivos fuente de los paquetes de desarrollo"
 
-#: pacaur:1169
+#: pacaur:1242
 #, fuzzy
 msgid "AUR source cache directory:"
 msgstr "Directorio de la caché de AUR:"
 
-#: pacaur:1171
+#: pacaur:1244
 #, fuzzy
 msgid "Do you want to remove all non development files from AUR source cache?"
 msgstr "¿Desea eliminar TODOS los archivos de la caché de AUR?"
 
-#: pacaur:1172
+#: pacaur:1245
 #, fuzzy
 msgid "removing non development files from source cache..."
 msgstr "eliminando todos los archivos de la caché de AUR..."
 
-#: pacaur:1176
+#: pacaur:1249
 #, fuzzy
 msgid "Do you want to remove ALL files from AUR source cache?"
 msgstr "¿Desea eliminar TODOS los archivos de la caché de AUR?"
 
-#: pacaur:1177
+#: pacaur:1250
 #, fuzzy
 msgid "removing all files from AUR source cache..."
 msgstr "eliminando todos los archivos de la caché de AUR..."
 
-#: pacaur:1270
+#: pacaur:1335
+msgid "Could not connect to the AUR"
+msgstr "No se pudo conectar a AUR"
+
+#: pacaur:1343
 msgid "failed to prepare transaction (could not satisfy dependencies)"
 msgstr ""
 "error al preparar la transacción (no se pudo satisfacer las dependencias)"
 
-#: pacaur:1271
+#: pacaur:1344
 msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: requiere $@"
 
-#: pacaur:1280
+#: pacaur:1353
 msgid "$2 [Y/n] "
 msgstr "$2 [S/n] "
 
-#: pacaur:1287
+#: pacaur:1360
 msgid "$2 [y/N] "
 msgstr "$2 [s/N] "
 
-#: pacaur:1318
+#: pacaur:1391
 msgid " there is nothing to do"
 msgstr " nada que hacer"
 
-#: pacaur:1338
+#: pacaur:1411
 #, fuzzy
 msgid "usage:  pacaur <operation> [options] [target(s)] -- See also pacaur(8)"
 msgstr "uso:  pacaur <operación> [opciones] [paquete(s)]"
 
-#: pacaur:1339
+#: pacaur:1412
 msgid "operations:"
 msgstr "operaciones:"
 
-#: pacaur:1340
+#: pacaur:1413
 msgid " pacman extension"
 msgstr " extensión de pacman"
 
-#: pacaur:1341
+#: pacaur:1414
 msgid "   -S, -Ss, -Si, -Sw, -Su, -Qu, -Sc, -Scc"
 msgstr ""
 
-#: pacaur:1342
+#: pacaur:1415
 #, fuzzy
 msgid "                    extend pacman operations to the AUR"
 msgstr "                    extender las operaciones de pacman a AUR"
 
-#: pacaur:1343
+#: pacaur:1416
 msgid " AUR specific"
 msgstr ""
 
-#: pacaur:1344
+#: pacaur:1417
 msgid "   -s, --search     search AUR for matching strings"
 msgstr "   -s, --search     buscar en AUR por las cadenas coincidentes"
 
-#: pacaur:1345
+#: pacaur:1418
 #, fuzzy
 msgid "   -i, --info       view package information"
 msgstr ""
 "   -i, --info       ver información del paquete (usar -ii para detalles)"
 
-#: pacaur:1346
+#: pacaur:1419
 msgid ""
 "   -d, --download   download target(s) -- pass twice to download AUR "
 "dependencies"
@@ -434,39 +516,39 @@ msgstr ""
 "   -d, --download   descargar objetivo(s) (usar -dd para descargar "
 "dependencias en AUR)"
 
-#: pacaur:1347
+#: pacaur:1420
 msgid "   -m, --makepkg    download and make target(s)"
 msgstr "   -m, --makepkg    descargar y construir objetivo(s)"
 
-#: pacaur:1348
+#: pacaur:1421
 msgid "   -y, --sync       download, make and install target(s)"
 msgstr "   -y, --sync       descargar, construir e instalar objetivo(s)"
 
-#: pacaur:1349
+#: pacaur:1422
 msgid "   -k, --check      check for AUR update(s)"
 msgstr "   -k, --check      comprobar actualizaciones de AUR"
 
-#: pacaur:1350
+#: pacaur:1423
 msgid "   -u, --update     update AUR package(s)"
 msgstr "   -u, --update     actualizar paquete(s) de AUR"
 
-#: pacaur:1351 pacaur:1359
+#: pacaur:1424 pacaur:1432
 msgid " general"
 msgstr " general"
 
-#: pacaur:1352
+#: pacaur:1425
 msgid "   -v, --version    display version information"
 msgstr "   -v, --version    mostrar información de versión"
 
-#: pacaur:1353
+#: pacaur:1426
 msgid "   -h, --help       display help information"
 msgstr "   -h, --help       mostrar información de ayuda"
 
-#: pacaur:1355
+#: pacaur:1428
 msgid "options:"
 msgstr "opciones:"
 
-#: pacaur:1356
+#: pacaur:1429
 msgid ""
 " pacman extension - can be used with the -S, -Ss, -Si, -Sii, -Sw, -Su, -Qu, -"
 "Sc, -Scc operations"
@@ -474,13 +556,13 @@ msgstr ""
 " extensión de pacman - puede ser usado con las operaciones -S, -Ss, -Si, -"
 "Sii, -Sw, -Su, -Qu, -Sc, -Scc"
 
-#: pacaur:1357
+#: pacaur:1430
 #, fuzzy
 msgid ""
 "   -a, --aur        only search, build or install target(s) from the AUR"
 msgstr "   -a, --aur        sólo buscar, instalar o limpiar paquetes de AUR"
 
-#: pacaur:1358
+#: pacaur:1431
 #, fuzzy
 msgid ""
 "   -r, --repo       only search, build or install target(s) from the "
@@ -489,62 +571,62 @@ msgstr ""
 "   -r, --repo       sólo buscar, instalar o limpiar paquetes de los "
 "repositorios"
 
-#: pacaur:1360
+#: pacaur:1433
 msgid "   -e, --edit       edit target(s) PKGBUILD and view install script"
 msgstr ""
 "   -e, --edit       editar PKGBUILD de objetivo(s) y ver el script de "
 "instalación"
 
-#: pacaur:1361
+#: pacaur:1434
 msgid "   -q, --quiet      show less information for query and search"
 msgstr "   -q, --quiet      muestra menos información en consulta y búsqueda"
 
-#: pacaur:1362
+#: pacaur:1435
 msgid "   --devel          consider AUR development packages upgrade"
 msgstr ""
 "   --devel          considera actualizaciones de paquetes AUR en desarrollo"
 
-#: pacaur:1363
+#: pacaur:1436
 msgid "   --foreign        consider already installed foreign dependencies"
 msgstr "   --foreign        considera las dependencias externas instaladas"
 
-#: pacaur:1364
+#: pacaur:1437
 msgid ""
 "   --ignore         ignore a package upgrade (can be used more than once)"
 msgstr ""
 "   --ignore         ignorar la actualización de un paquete (puede ser usado "
 "más de una vez)"
 
-#: pacaur:1365
+#: pacaur:1438
 #, fuzzy
 msgid "   --needed         do not reinstall already up-to-date target(s)"
 msgstr "   --noedit         no pedir editar archivos"
 
-#: pacaur:1366
+#: pacaur:1439
 msgid "   --noconfirm      do not prompt for any confirmation"
 msgstr "   --noconfirm      no pedir ninguna confirmación"
 
-#: pacaur:1367
+#: pacaur:1440
 msgid "   --noedit         do not prompt to edit files"
 msgstr "   --noedit         no pedir editar archivos"
 
-#: pacaur:1368
+#: pacaur:1441
 msgid "   --rebuild        always rebuild package(s)"
 msgstr "   --rebuild        siempre reconstruir paquete(s)"
 
-#: pacaur:1369
+#: pacaur:1442
 msgid "   --silent         silence output"
 msgstr "   --silent         silencia la salida"
 
-#: pacaur:1493
+#: pacaur:1566
 msgid "you cannot perform this operation as root"
 msgstr "no puede realizar esta operación como root"
 
-#: pacaur:1497
+#: pacaur:1570
 msgid "${colorW}editor${reset} variable unset"
 msgstr "La variable ${colorW}editor${reset} no está definida"
 
-#: pacaur:1498
+#: pacaur:1571
 msgid ""
 "${colorW}clonedir${reset} or ${colorW}\\$AURDEST${reset} should be set to a "
 "non volatile memory location"
@@ -552,20 +634,20 @@ msgstr ""
 "${colorW}clonedir${reset} o ${colorW}\\$AURDEST${reset} debe ser configurada "
 "como una ubicación no volátil"
 
-#: pacaur:1499
+#: pacaur:1572
 #, fuzzy
 msgid "${colorW}$clonedir${reset} does not have write permission."
 msgstr "${colorW}$builddir${reset} no posee permisos de escritura."
 
-#: pacaur:1500
+#: pacaur:1573 pacaur:1574
 msgid "no targets specified (use -h for help)"
 msgstr "no se indicaron objetivos (use -h para ayuda)"
 
-#: pacaur:1501
+#: pacaur:1575
 msgid "target not found"
 msgstr "objetivo no encontrado"
 
-#: pacaur:1542 pacaur:1554 pacaur:1566
+#: pacaur:1616 pacaur:1628 pacaur:1640
 msgid ""
 "Package(s) ${colorW}${aurpkgs[*]}${reset} not found in repositories, trying "
 "${colorM}AUR${reset}..."
@@ -608,9 +690,6 @@ msgstr ""
 
 #~ msgid "Build directory already cleaned"
 #~ msgstr "Directorio de construcción ya se había limpiado"
-
-#~ msgid "Could not connect to the AUR"
-#~ msgstr "No se pudo conectar a AUR"
 
 #~ msgid " AUR only"
 #~ msgstr " solo AUR"


### PR DESCRIPTION
The search of AUR information is now formatted in `pacaur`. Information is still fetched using `cower` but the style is closer to `pacman -Si` output.

I've tested this code in LANG=en_US.UTF-8 and LANG=es_ES.UTF-8 and it seems to work.

_Edit: related to #329_ 