### PR TITLE
Fix loading config from second XDG_CONFIG_DIRS path

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -22,7 +22,7 @@ TEXTDOMAINDIR='/usr/share/locale'
 # determine config location
 if [[ -n "${XDG_CONFIG_DIRS}" ]]; then
     for i in ${XDG_CONFIG_DIRS//:/ }; do
-        [[ -d "$i" ]] && export XDG_CONFIG_DIRS="$i" && break
+        [[ -d "$i/pacaur" ]] && export XDG_CONFIG_DIRS="$i" && break
     done
 fi
 configdir="${XDG_CONFIG_DIRS:-/etc/xdg}/pacaur"


### PR DESCRIPTION
This fixes loading the pacaur configuration from the later paths in `$XDG_CONFIG_DIRS` if the `pacaur` directory does not exist in earlier paths.

Eg, if `XDG_CONFIG_DIRS="/tmp/blah:${HOME}/.config"`, then pacaur will now load `~/.config/pacaur` if `/tmp/blah/pacaur` does not exist.