### PR TITLE
Prefer $VISUAL over $EDITOR

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -249,7 +249,7 @@ The available options are:
 
 =item B<editor>
 
-Define the editor. Default is B<$EDITOR>, with a fallback on I<vi>.
+Define the editor. Default is B<$VISUAL>, with a fallback on B<$EDITOR> and I<vi>.
 
 =item B<displaybuildfiles>
 

--- a/config
+++ b/config
@@ -9,7 +9,7 @@
 # The Color and VerbosePkgLists options can be enabled in /etc/pacman.conf.
 # The clone directory can be changed through the $AURDEST environment variable.
 # The makepkg environment variables are also fully honored.
-#editor="${EDITOR:-vi}"                # build files editor
+#editor="${VISUAL:-${EDITOR:-vi}}"     # build files editor
 #displaybuildfiles=diff                # display build files (none|diff|full)
 #fallback=true                         # pacman fallback to the AUR
 #silent=false                          # silence output

--- a/pacaur
+++ b/pacaur
@@ -43,7 +43,7 @@ else
 fi
 
 # set default config variables
-editor="${EDITOR:-vi}"                      # build files editor
+editor="${VISUAL:-${EDITOR:-vi}}"           # build files editor
 displaybuildfiles=diff                      # display build files (none|diff|full)
 fallback=true                               # pacman fallback to the AUR
 silent=false                                # silence output


### PR DESCRIPTION
Many programs use VISUAL if defined, or EDITOR if VISUAL is not defined. pacaur should behave the same.