### PR TITLE
Allow cower to become an optional dependency.

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1208,12 +1208,20 @@ SearchAur() {
     if [[ -z "$(grep -E "\-\-[r]?sort" <<< ${coweropts[@]})" ]]; then
         [[ $sortorder = descending ]] && coweropts+=("--rsort=$sortby") || coweropts+=("--sort=$sortby");
     fi
+    if ! cower -V > /dev/null; then
+	Note "e" $"cower is not installed, searching the AUR is not available"
+	exit 1
+    fi
     cower ${coweropts[@]} -- $@
 }
 
 InfoAur() {
     local aurinfopkgs info infolabel maxlength linfo lbytes
 
+    if ! cower -V > /dev/null; then
+	Note "e" $"cower is not installed, cannot get info on AUR packages"
+	exit 1
+    fi
     readarray aurinfopkgs < <(cower ${coweropts[@]} --format "%n|%v|%d|%u|%p|%L|%W|%P|%D|%M|%O|%C|%R|%m|%r|%o|%t|%s|%a\n" $@)
     aurinfopkgsQname=($(expac -Q '%n' $@))
     aurinfopkgsQver=($(expac -Q '%v' $@))


### PR DESCRIPTION
Since cower is only used for search and getting package information,
it isn't necessary for things like installing and updating.  This
makes it easier to bootstrap pacaur on new systems when all you want
is to install or update AUR packages.