### PR TITLE
Fix an error on linux-grsec

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1545,10 +1545,10 @@ GetJson() {
     if json_verify -q <<< "$2"; then
         case "$1" in
             var)
-                json_reformat <<< "$2" | tr -d "\", " | grep -Po "$3:.*" | sed -r "s/$3:/$3#/g" | awk -F "#" '{print $2}';;
+                json_reformat <<< "$2" | tr -d "\", " | perl -ne "print \$& . \"\n\" if /$3:.*/" | sed -r "s/$3:/$3#/g" | awk -F "#" '{print $2}';;
             varvar)
                 json_reformat <<< "$2" | tr -d ", " | sed -e "/\"Name\":\"$4\"/,/}/!d" | \
-                tr -d "\"" | grep -Po "$3:.*" | sed -r "s/$3:/$3#/g" | awk -F "#" '{print $2}';;
+                tr -d "\"" | perl -ne "print \$& . \"\n\" if /$3:.*/" | sed -r "s/$3:/$3#/g" | awk -F "#" '{print $2}';;
             array)
                 json_reformat <<< "$2" | tr -d ", " | sed -e "/^\"$3\"/,/]/!d" | tr -d '\"' \
                 | tr '\n' ' ' | sed "s/] /]\n/g" | cut -d' ' -f 2- | tr -d '[]"' | tr -d '\n';;


### PR DESCRIPTION
Using perl regexes in grep requires RWX anonymous mmap which is
prohibited by the linux-grsec kernel.  Normally, special flags are
added to binaries that need these mappings but that is not the case
for grep (people don't normally use perl regex's in grep).  By using
perl instead, users don't have to add the flag themselves.  This is
not a huge issue since perl is almost always installed on a user's
system.