### PR TITLE
Fixed Proceed() so that it defaults to the expected action

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1682,8 +1682,8 @@ Proceed() {
                 echo
             fi
             case $answer in
-                $Y|$y|'') return 0;;
-                *) return 1;;
+                $N|$n) return 1;;
+                *) return 0;;
             esac;;
         n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [y/N] "
             if [[ ! $noconfirm ]]; then
@@ -1705,8 +1705,8 @@ Proceed() {
                 echo
             fi
             case $answer in
-                $N|$n|'') return 0;;
-                *) return 1;;
+                $Y|$y) return 1;;
+                *) return 0;;
             esac;;
     esac
 }


### PR DESCRIPTION
Previously, at a `Y/n` proceed prompt, pressing just about any random key except `Y y enter space` would be interpreted as No. With this change, only `N n` is interpreted as No, everything else as Yes, as you would expect.