### PR TITLE
Do not run prepare() during integrity check

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1126,7 +1126,7 @@ MakePkgs() {
             fi
             (($? > 0)) && errmakepkg+=(${pkgsdeps[$i]})
             # silent extraction and pkgver update only
-            makepkg -od --skipinteg ${makeopts[@]} &>/dev/null
+            makepkg -od --noprepare --skipinteg ${makeopts[@]} &>/dev/null
         fi
     done
     if [[ -n "${errmakepkg[@]}" ]]; then


### PR DESCRIPTION
Fixed #645. This could cause some packages to fail to build, as patches
may be applied in prepare(), and re-running it would fail to apply those
patches.