### PR TITLE
Allow prepare() to modify pkgver()

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1126,7 +1126,7 @@ MakePkgs() {
             fi
             (($? > 0)) && errmakepkg+=(${pkgsdeps[$i]})
             # silent extraction and pkgver update only
-            makepkg -od --noprepare --skipinteg ${makeopts[@]} &>/dev/null
+            makepkg -od --skipinteg ${makeopts[@]} &>/dev/null
         fi
     done
     if [[ -n "${errmakepkg[@]}" ]]; then
@@ -1216,9 +1216,9 @@ MakePkgs() {
         fi
 
         if [[ $silent = true ]]; then
-            makepkg -sfc ${makeopts[@]} --noconfirm &>/dev/null
+            makepkg -sfc ${makeopts[@]} --noextract --noconfirm &>/dev/null
         else
-            makepkg -sfc ${makeopts[@]} --noconfirm
+            makepkg -sfc ${makeopts[@]} --noextract --noconfirm
         fi
 
         # error check


### PR DESCRIPTION
See discussion in #645. Originally, (in 40e4f07) --noprepare was removed
from makepkg during the integrity check code because prepare() could
change the pkgver. This caused another bug, that prepare() was performed
multiple times, causing things like patching to fail, so this was
reverted in 71d698e.

The proper fix is to *only* run prepare() during the early phase, and
use the results in the build.

This was tested with `linux-cdown`, which builds successfully with this
patch.