### PR TITLE
Fix missing trailing whitespace on intl. locales

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1709,7 +1709,7 @@ Proceed() {
     Y="$(gettext pacman Y)"; y="${Y,,}";
     N="$(gettext pacman N)"; n="${N,,}"
     case "$1" in
-        y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [Y/n] "
+        y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [Y/n]" ""
             if [[ ! $noconfirm ]]; then
                 case "$TERM" in
                     dumb)
@@ -1732,7 +1732,7 @@ Proceed() {
                 $Y|$y|'') return 0;;
                 *) return 1;;
             esac;;
-        n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [y/N] "
+        n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [y/N]" ""
             if [[ ! $noconfirm ]]; then
                 case "$TERM" in
                     dumb)

--- a/po/ca.po
+++ b/po/ca.po
@@ -373,12 +373,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: requereix $@"
 
 #: pacaur:1252
-msgid "$2 [Y/n] "
-msgstr "$2 [S/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [S/n]"
 
 #: pacaur:1259
-msgid "$2 [y/N] "
-msgstr "$2 [s/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [s/N]"
 
 #: pacaur:1290
 msgid " there is nothing to do"

--- a/po/da.po
+++ b/po/da.po
@@ -365,12 +365,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: kræver $@"
 
 #: pacaur:1302
-msgid "$2 [Y/n] "
-msgstr "$2 [J/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [J/n]"
 
 #: pacaur:1309
-msgid "$2 [y/N] "
-msgstr "$2 [j/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [j/N]"
 
 #: pacaur:1340
 msgid " there is nothing to do"

--- a/po/de.po
+++ b/po/de.po
@@ -376,12 +376,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: Hängt ab von $@"
 
 #: pacaur:1299
-msgid "$2 [Y/n] "
-msgstr "$2 [J/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [J/n]"
 
 #: pacaur:1306
-msgid "$2 [y/N] "
-msgstr "$2 [j/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [j/N]"
 
 #: pacaur:1337
 msgid " there is nothing to do"

--- a/po/es.po
+++ b/po/es.po
@@ -523,12 +523,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: requiere $@"
 
 #: pacaur:1670
-msgid "$2 [Y/n] "
-msgstr "$2 [S/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [S/n]"
 
 #: pacaur:1693
-msgid "$2 [y/N] "
-msgstr "$2 [s/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [s/N]"
 
 #: pacaur:1740
 msgid " there is nothing to do"

--- a/po/fi.po
+++ b/po/fi.po
@@ -508,12 +508,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: vaatii $@"
 
 #: pacaur:1589
-msgid "$2 [Y/n] "
-msgstr "$2 [K/e] "
+msgid "$2 [Y/n]"
+msgstr "$2 [K/e]"
 
 #: pacaur:1608
-msgid "$2 [y/N] "
-msgstr "$2 [k/E] "
+msgid "$2 [y/N]"
+msgstr "$2 [k/E]"
 
 #: pacaur:1651
 msgid " there is nothing to do"

--- a/po/fr.po
+++ b/po/fr.po
@@ -373,12 +373,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: requiert $@"
 
 #: pacaur:1252
-msgid "$2 [Y/n] "
-msgstr "$2 [O/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [O/n]"
 
 #: pacaur:1259
-msgid "$2 [y/N] "
-msgstr "$2 [o/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [o/N]"
 
 #: pacaur:1290
 msgid " there is nothing to do"

--- a/po/hu.po
+++ b/po/hu.po
@@ -368,12 +368,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: $@ hiányzik"
 
 #: pacaur:1280
-msgid "$2 [Y/n] "
-msgstr "$2 [I/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [I/n]"
 
 #: pacaur:1287
-msgid "$2 [y/N] "
-msgstr "$2 [i/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [i/N]"
 
 #: pacaur:1318
 msgid " there is nothing to do"

--- a/po/it.po
+++ b/po/it.po
@@ -370,11 +370,11 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: richiede $@"
 
 #: pacaur:1252
-msgid "$2 [Y/n] "
+msgid "$2 [Y/n]"
 msgstr "$2 [S/n]"
 
 #: pacaur:1259
-msgid "$2 [y/N] "
+msgid "$2 [y/N]"
 msgstr "$2 [s/N]"
 
 #: pacaur:1290

--- a/po/ja.po
+++ b/po/ja.po
@@ -367,11 +367,11 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: $@ に依存しています"
 
 #: pacaur:1280
-msgid "$2 [Y/n] "
+msgid "$2 [Y/n]"
 msgstr "$2 [Y/n]"
 
 #: pacaur:1287
-msgid "$2 [y/N] "
+msgid "$2 [y/N]"
 msgstr "$2 [y/N]"
 
 #: pacaur:1318

--- a/po/nb.po
+++ b/po/nb.po
@@ -463,12 +463,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr ""
 
 #: pacaur:1571
-msgid "$2 [Y/n] "
-msgstr "$2 [J/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [J/n]"
 
 #: pacaur:1582
-msgid "$2 [y/N] "
-msgstr "$2 [j/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [j/N]"
 
 #: pacaur:1617
 msgid " there is nothing to do"

--- a/po/nl.po
+++ b/po/nl.po
@@ -509,11 +509,11 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: vereist $@"
 
 #: pacaur:1588
-msgid "$2 [Y/n] "
+msgid "$2 [Y/n]"
 msgstr "$2 [J/n]"
 
 #: pacaur:1607
-msgid "$2 [y/N] "
+msgid "$2 [y/N]"
 msgstr "$2 [j/N]"
 
 #: pacaur:1650

--- a/po/pl.po
+++ b/po/pl.po
@@ -370,12 +370,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: wymaga $@"
 
 #: pacaur:1299
-msgid "$2 [Y/n] "
-msgstr "$2 [T/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [T/n]"
 
 #: pacaur:1306
-msgid "$2 [y/N] "
-msgstr "$2 [t/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [t/N]"
 
 #: pacaur:1337
 msgid " there is nothing to do"

--- a/po/pt.po
+++ b/po/pt.po
@@ -355,11 +355,11 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: requer $@"
 
 #: pacaur:1252
-msgid "$2 [Y/n] "
+msgid "$2 [Y/n]"
 msgstr "$2 [S/n]"
 
 #: pacaur:1259
-msgid "$2 [y/N] "
+msgid "$2 [y/N]"
 msgstr "$2 [s/N]"
 
 #: pacaur:1290

--- a/po/ru.po
+++ b/po/ru.po
@@ -366,12 +366,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: требует $@"
 
 #: pacaur:1280
-msgid "$2 [Y/n] "
-msgstr "$2 [Y/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [Y/n]"
 
 #: pacaur:1287
-msgid "$2 [y/N] "
-msgstr "$2 [y/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [y/N]"
 
 #: pacaur:1318
 msgid " there is nothing to do"

--- a/po/sk.po
+++ b/po/sk.po
@@ -369,12 +369,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: vyžaduje $@"
 
 #: pacaur:1280
-msgid "$2 [Y/n] "
-msgstr "$2 [A/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [A/n]"
 
 #: pacaur:1287
-msgid "$2 [y/N] "
-msgstr "$2 [a/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [a/N]"
 
 #: pacaur:1318
 msgid " there is nothing to do"

--- a/po/sl.po
+++ b/po/sl.po
@@ -524,12 +524,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: potrebuje $@"
 
 #: pacaur:1665
-msgid "$2 [Y/n] "
-msgstr "$2 [Y/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [Y/n]"
 
 #: pacaur:1688
-msgid "$2 [y/N] "
-msgstr "$2 [y/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [y/N]"
 
 #: pacaur:1735
 msgid " there is nothing to do"

--- a/po/sr.po
+++ b/po/sr.po
@@ -366,12 +366,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: захтева $@"
 
 #: pacaur:1298
-msgid "$2 [Y/n] "
-msgstr "$2 [Д/н] "
+msgid "$2 [Y/n]"
+msgstr "$2 [Д/н]"
 
 #: pacaur:1305
-msgid "$2 [y/N] "
-msgstr "$2 [д/Н] "
+msgid "$2 [y/N]"
+msgstr "$2 [д/Н]"
 
 #: pacaur:1336
 msgid " there is nothing to do"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -366,12 +366,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: zahteva $@"
 
 #: pacaur:1298
-msgid "$2 [Y/n] "
-msgstr "$2 [D/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [D/n]"
 
 #: pacaur:1305
-msgid "$2 [y/N] "
-msgstr "$2 [d/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [d/N]"
 
 #: pacaur:1336
 msgid " there is nothing to do"

--- a/po/tr.po
+++ b/po/tr.po
@@ -370,12 +370,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: $@ gerektirir"
 
 #: pacaur:1252
-msgid "$2 [Y/n] "
-msgstr "$2 [E/h] "
+msgid "$2 [Y/n]"
+msgstr "$2 [E/h]"
 
 #: pacaur:1259
-msgid "$2 [y/N] "
-msgstr "$2 [e/H] "
+msgid "$2 [y/N]"
+msgstr "$2 [e/H]"
 
 #: pacaur:1290
 msgid " there is nothing to do"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -486,12 +486,12 @@ msgid "${Qrequires[@]}: requires $@"
 msgstr "${Qrequires[@]}: 需要 $@"
 
 #: pacaur:1670
-msgid "$2 [Y/n] "
-msgstr "$2 [Y/n] "
+msgid "$2 [Y/n]"
+msgstr "$2 [Y/n]"
 
 #: pacaur:1693
-msgid "$2 [y/N] "
-msgstr "$2 [y/N] "
+msgid "$2 [y/N]"
+msgstr "$2 [y/N]"
 
 #: pacaur:1740
 msgid " there is nothing to do"


### PR DESCRIPTION
If you're not using an en-US locale, pacaur doesn't add a trailing
whitespace at the end of messages that require user input. It's a
silly thing, but it looks ugly and I just decided to fix it.