### PR TITLE
Also use pacman localization in Proceed prompt

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1709,7 +1709,7 @@ Proceed() {
     Y="$(gettext pacman Y)"; y="${Y,,}";
     N="$(gettext pacman N)"; n="${N,,}"
     case "$1" in
-        y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [Y/n] "
+        y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$Y/$n] "
             if [[ ! $noconfirm ]]; then
                 case "$TERM" in
                     dumb)
@@ -1732,7 +1732,7 @@ Proceed() {
                 $Y|$y|'') return 0;;
                 *) return 1;;
             esac;;
-        n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" $"$2 [y/N] "
+        n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$y/$N] "
             if [[ ! $noconfirm ]]; then
                 case "$TERM" in
                     dumb)


### PR DESCRIPTION
Prevents a mismatch of Y/N in prompt and input check if pacaur doesn't
have a localized "[Y/N]" prompt but pacman has a localized "Y" and
"N" (#436).