### PR TITLE
Remove trailing whitespace from verbose package list

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -947,9 +947,13 @@ Prompt() {
             [[ "${depsQver[$i]}" =~ '#' ]] && unset depsQver[$i]
         done
         # show detailed output
-        printf "\n${colorW}%-${lname}s  %-${lver}s  %-${lver}s${reset}\n\n" "$straurname" "$stroldver" "$strnewver"
+        printf "\n${colorW}%-${lname}s  %-${lver}s  %s${reset}\n\n" "$straurname" "$stroldver" "$strnewver"
         for i in "${!deps[@]}"; do
-            printf "%-${lname}s  ${colorR}%-${lver}s${reset}  ${colorG}%-${lver}s${reset}  %${lsize}s\n" "${depsArepo[$i]}" "${depsQver[$i]}" "${depsAver[$i]}" "${depsAcached[$i]}";
+            if [ -n "${depsAcached[$i]}" ]; then
+                printf "%-${lname}s  ${colorR}%-${lver}s${reset}  ${colorG}%-${lver}s${reset}  %s\n" "${depsArepo[$i]}" "${depsQver[$i]}" "${depsAver[$i]}" "${depsAcached[$i]}";
+            else
+                printf "%-${lname}s  ${colorR}%-${lver}s${reset}  ${colorG}%s${reset}\n" "${depsArepo[$i]}" "${depsQver[$i]}" "${depsAver[$i]}";
+            fi
         done
 
         if [[ -n "${repodepspkgs[@]}" ]]; then


### PR DESCRIPTION
For some reason pacaur prints a lot of trailing whitespace after verbose package lists, for example 

    AUR Packages  (1)                    Old Version          New Version        
    
    aur/termite-ranger-fix-terminfo-git  1:10.113.g5893994-1  latest                            

which causes the lines to break, and makes the table all ugly when using a small terminal.

This change fixes the issue for me, but I'm not terribly good at bash, so I'm sure there's something I'm missing.
