### PR TITLE
Also parse global pacman.conf IgnoreGroup

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1600,6 +1600,8 @@ CleanCache() {
 GetIgnoredPkgs() {
     # global ignoredpkgs
     ignoredpkgs+=($(grep '^IgnorePkg' '/etc/pacman.conf' | awk -F '=' '{print $NF}' | tr -d "'\""))
+    local ignoredgrps=$(grep '^IgnoreGroup' '/etc/pacman.conf' | awk -F '=' '{print $NF}')
+    [[ -n $ignoredgrps ]] && ignoredpkgs+=($($pacmanbin -Qq --groups $ignoredgrps 2>/dev/null | tr '\n' ' '))
     [[ -e "$HOME/.config/cower/config" ]] && ignoredpkgs+=($(grep '^IgnorePkg' "$HOME/.config/cower/config" | awk -F '=' '{print $NF}' | tr -d "'\""))
     ignoredpkgs=(${ignoredpkgs[@]//,/ })
 }


### PR DESCRIPTION
Testing the waters with this PR, as this has been discussed and declared wontfix in the past.

I, like apparently some others (#388), have been using the (somewhat questionable) method [mentioned in the wiki](https://wiki.archlinux.org/index.php/Arch_Build_System#Preserve_modified_packages) to prevent locally modified packages from being updated by editing the PKGBUILDs and adding a custom group, which is then added to pacman.conf's IgnoreGroup directive.

This would add any installed packages that are members of ignored groups to the list of ignored packages.