### PR TITLE
Don't pass --quiet to pacman -U

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1336,7 +1336,7 @@ MakePkgs() {
                 Note "f" $"${colorW}${pkgsdeps[$i]}${reset} package(s) failed to install. Check .SRCINFO for mismatching data with PKGBUILD."
                 errinstall+=(${pkgsdeps[$i]})
             else
-                sudo $pacmanbin -Ud ${builtdepspkgs[@]} ${builtpkgs[@]} --ask 36 ${pacopts[@]} --noconfirm
+                sudo $pacmanbin -Ud ${builtdepspkgs[@]} ${builtpkgs[@]} --ask 36 ${pacopts[@]/--quiet} --noconfirm
             fi
         fi
 


### PR DESCRIPTION
When invoking `pacaur -Syuq`, `--quiet` gets passed to `pacman -U`, which then aborts the instalation because it doesn't recognize the option.

Relevant logs:

```bash
+ Note i 'Installing \e[1;39madapta-gtk-theme\e[0m package(s)...'
+ case "$1" in
+ echo -e '\e[1;34m::\e[0m Installing \e[1;39madapta-gtk-theme\e[0m package(s)...'
+ [[ -z '' ]]
+ [[ -z /home/rzl/.cache/pacaur/adapta-gtk-theme/adapta-gtk-theme-3.91.0.45-1-any.pkg.tar.xz ]]
+ sudo pacman -Ud /home/rzl/.cache/pacaur/adapta-gtk-theme/adapta-gtk-theme-3.91.0.45-1-any.pkg.tar.xz --ask 36 --quiet --noconfirm
error: invalid option '--quiet'
+ [[ -n true ]]
```