### PR TITLE
Add some comments to several functions

### DIFF
--- a/libpacaur/cache.sh
+++ b/libpacaur/cache.sh
@@ -10,6 +10,7 @@
 # usage: CleanCache( $packages )
 ##
 CleanCache() {
+    # clean AUR sources cache
     if [[ $SRCDEST ]]; then
         [[ $count -eq 1 ]] && printf "\n%s\n %s\n" $"Sources to keep:" $"All development packages sources"
         printf "\n%s %s\n" $"AUR source cache directory:" "$SRCDEST"
@@ -25,6 +26,7 @@ CleanCache() {
             fi
         fi
     fi
+    # clean clone directory cache
     if [[ -d "$clonedir" ]]; then
         cd $clonedir
         [[ $count -eq 1 ]] && printf "\n%s\n %s\n" $"Clones to keep:" $"All packages clones"

--- a/libpacaur/checks.sh
+++ b/libpacaur/checks.sh
@@ -27,7 +27,7 @@ IgnoreChecks() {
 
     checkaurpkgsAver=($(GetJson "var" "$json" "Version"))
     checkaurpkgsQver=($(expac -Q '%v' "${checkaurpkgs[@]}"))
-    # set always the latest revision for devel packages since RPC can be outdated
+    # set always the latest revision for devel packages since the RPC data is static only
     for i in "${!checkaurpkgs[@]}"; do
         [[ -n "$(grep -E "\-(cvs|svn|git|hg|bzr|darcs|nightly.*)$" <<< ${checkaurpkgs[$i]})" ]] && checkaurpkgsAver[$i]=$"latest"
     done

--- a/libpacaur/deps.sh
+++ b/libpacaur/deps.sh
@@ -397,7 +397,7 @@ FindDepsRepo() {
     [[ -z "${repodepspkgs[@]}" ]] && repodepspkgs=(${repodeps[@]})
 
     # get non installed repo deps
-    allrepodepspkgs=($(expac -S -1 '%E' ${repodeps[@]})) # no version check needed as all deps are repo
+    allrepodepspkgs=($(expac -S -1 '%E' ${repodeps[@]})) # no version check needed as all deps are repo deps
     [[ -n "${allrepodepspkgs[@]}" ]] && repodepspkgstmp=($($pacmanbin -T ${allrepodepspkgs[@]} | sort -u))
 
     if [[ -n "${repodepspkgstmp[@]}" ]]; then
@@ -425,7 +425,7 @@ FindDepsRepoProvider() {
     [[ -z "${providerspkgspkgs[@]}" ]] && providerspkgspkgs=(${providerspkgs[@]})
 
     # get non installed repo deps
-    allproviderrepodepspkgs=($(expac -S -1 '%E' ${providerspkgs[@]})) # no version check needed as all deps are repo
+    allproviderrepodepspkgs=($(expac -S -1 '%E' ${providerspkgs[@]})) # no version check needed as all deps are repo deps
     [[ -n "${allproviderrepodepspkgs[@]}" ]] && providerrepodepspkgstmp=($($pacmanbin -T ${allproviderrepodepspkgs[@]} | sort -u))
 
     if [[ -n "${providerrepodepspkgstmp[@]}" ]]; then

--- a/libpacaur/deps.sh
+++ b/libpacaur/deps.sh
@@ -100,7 +100,7 @@ DepsSolver() {
         exit 1
     fi
 
-    # return all binary deps
+    # return all repo deps
     FindDepsRepo ${repodeps[@]}
 
     # avoid possible duplicate
@@ -216,13 +216,13 @@ FindDepsAur() {
             depspkgstmp+=($(grep -xvf <(printf '%s\n' "${vcsdepspkgs[@]}") <(printf '%s\n' "${depspkgs[@]}")))
             depspkgs=($(tr ' ' '\n' <<< ${depspkgstmp[@]} | LC_COLLATE=C sort -u))
         fi
-        # remove installed binary packages only
+        # remove installed repo packages only
         if [[ $foreign ]]; then
             depspkgs=($(grep -xf <(printf '%s\n' "${depspkgs[@]}") <(printf '%s\n' "${foreignpkgs[@]}")))
         fi
     fi
 
-    # split binary and AUR depends pkgs
+    # split repo and AUR depends pkgs
     unset depspkgsaur
     if [[ -n "${depspkgs[@]}" ]]; then
         # remove all pkgs versioning
@@ -390,14 +390,14 @@ FindDepsRepo() {
     # global repodeps repodepspkgs
     [[ -z "${repodeps[@]}" ]] && return
 
-    # reduce root binary deps
+    # reduce root repo deps
     repodeps=($(tr ' ' '\n' <<< ${repodeps[@]} | sort -u))
 
     # add initial repodeps
     [[ -z "${repodepspkgs[@]}" ]] && repodepspkgs=(${repodeps[@]})
 
     # get non installed repo deps
-    allrepodepspkgs=($(expac -S -1 '%E' ${repodeps[@]})) # no version check needed as all deps are binary
+    allrepodepspkgs=($(expac -S -1 '%E' ${repodeps[@]})) # no version check needed as all deps are repo
     [[ -n "${allrepodepspkgs[@]}" ]] && repodepspkgstmp=($($pacmanbin -T ${allrepodepspkgs[@]} | sort -u))
 
     if [[ -n "${repodepspkgstmp[@]}" ]]; then
@@ -418,14 +418,14 @@ FindDepsRepoProvider() {
     # global repodeps repodepspkgs
     [[ -z "${providerspkgs[@]}" ]] && return
 
-    # reduce root binary deps
+    # reduce root repo deps
     providerspkgs=($(tr ' ' '\n' <<< ${providerspkgs[@]} | sort -u))
 
     # add initial repodeps
     [[ -z "${providerspkgspkgs[@]}" ]] && providerspkgspkgs=(${providerspkgs[@]})
 
     # get non installed repo deps
-    allproviderrepodepspkgs=($(expac -S -1 '%E' ${providerspkgs[@]})) # no version check needed as all deps are binary
+    allproviderrepodepspkgs=($(expac -S -1 '%E' ${providerspkgs[@]})) # no version check needed as all deps are repo
     [[ -n "${allproviderrepodepspkgs[@]}" ]] && providerrepodepspkgstmp=($($pacmanbin -T ${allproviderrepodepspkgs[@]} | sort -u))
 
     if [[ -n "${providerrepodepspkgstmp[@]}" ]]; then

--- a/libpacaur/main.sh
+++ b/libpacaur/main.sh
@@ -35,6 +35,7 @@ Prompt() {
     local i binaryksize sumk summ builtpkg cachedpkgs strname stroldver strnewver strsize action
     local depsver repodepspkgsver strrepodlsize strrepoinsize strsumk strsumm lreposizelabel lreposize
     # global repodepspkgs repodepsSver depsAname depsAver depsArepo depsAcached lname lver lsize deps depsQver repodepspkgs repodepsSrepo repodepsQver repodepsSver
+
     # compute binary size
     if [[ -n "${repodepspkgs[@]}" ]]; then
         binaryksize=($(expac -S -1 '%k' "${repodepspkgs[@]}"))
@@ -59,6 +60,7 @@ Prompt() {
         unset builtpkg
     done
 
+    # use output verbosity options from pacman config file
     if [[ -n "$(grep '^VerbosePkgLists' '/etc/pacman.conf')" ]]; then
         straurname=$"AUR Packages  (${#deps[@]})"; strreponame=$"Repo Packages (${#repodepspkgs[@]})"; stroldver=$"Old Version"; strnewver=$"New Version"; strsize=$"Download Size"
         depsArepo=(${depsAname[@]/#/aur/})
@@ -76,6 +78,7 @@ Prompt() {
             printf "%-${lname}s  ${colorR}%-${lver}s${reset}  ${colorG}%-${lver}s${reset}  %${lsize}s\n" "${depsArepo[$i]}" "${depsQver[$i]}" "${depsAver[$i]}" "${depsAcached[$i]}";
         done
 
+        # format and print binary size
         if [[ -n "${repodepspkgs[@]}" ]]; then
             for i in "${!repodepspkgs[@]}"; do
                 binarysize[$i]=$(awk '{ printf("%.2f\n", $1/$2) }' <<< "${binaryksize[$i]} 1048576")
@@ -97,6 +100,7 @@ Prompt() {
         [[ -n "${repodepspkgs[@]}" ]] && printf "${colorW}%-16s${reset} %s\n" $"Repo Packages (${#repodepspkgs[@]})" "$repodepspkgsver"
     fi
 
+    # show total download and installed size of the operation
     if [[ -n "${repodepspkgs[@]}" ]]; then
         strrepodlsize=$"Repo Download Size:"; strrepoinsize=$"Repo Installed Size:"; strsumk=$"$sumk MiB"; strsumm=$"$summ MiB"
         lreposizelabel=$(GetLength "$strrepodlsize" "$strrepoinsize")

--- a/libpacaur/pkgs.sh
+++ b/libpacaur/pkgs.sh
@@ -75,6 +75,7 @@ EditPkgs() {
         cd "$clonedir/$i" || exit 1
         unset timestamp
         GetInstallScripts $i
+        # ask for showing files and diff when edit argument is not used
         if [[ ! $edit ]]; then
             if [[ ! $displaybuildfiles = none ]]; then
                 if [[ $displaybuildfiles = diff && -e ".git/HEAD.prev" ]]; then
@@ -136,6 +137,7 @@ EditPkgs() {
         fi
     done
 
+    # handle errors on viewing package install script and pkgbuild
     if [[ -n "${erreditpkg[@]}" ]]; then
         for i in "${erreditpkg[@]}"; do
             Note "f" $"${colorW}$i${reset} errored on exit"
@@ -212,6 +214,7 @@ MakePkgs() {
             fi
         done
 
+        # verify source integrity
         if [[ ! $builtpkg || $rebuild ]]; then
             cd "$clonedir/${basepkgs[$i]}" || exit 1
             Note "i" $"Checking ${colorW}${pkgsdeps[$i]}${reset} integrity..."
@@ -225,6 +228,8 @@ MakePkgs() {
             makepkg -odC --skipinteg ${makeopts[@]} &>/dev/null
         fi
     done
+
+    # handle errors on integrity check
     if [[ -n "${errmakepkg[@]}" ]]; then
         for i in "${errmakepkg[@]}"; do
             Note "f" $"failed to verify ${colorW}$i${reset} integrity"
@@ -300,7 +305,7 @@ MakePkgs() {
         # build
         Note "i" $"Building ${colorW}${pkgsdeps[$i]}${reset} package(s)..."
 
-        # install then remove binary deps
+        # build then remove binary deps
         makeopts=(${makeopts[@]/-r/})
 
         if [[ ! $installpkg ]]; then
@@ -367,7 +372,7 @@ MakePkgs() {
             Note "i" $"Removing installed AUR dependencies..."
             sudo $pacmanbin -Rsn ${aurdepspkgs[@]} --noconfirm
         fi
-        # readd removed conflicting packages
+        # read removed conflicting packages
         [[ -n "${aurconflictingpkgsrm[@]}" ]] && sudo $pacmanbin -S ${aurconflictingpkgsrm[@]} --ask 36 --asdeps --needed --noconfirm
         [[ -n "${repoconflictingpkgsrm[@]}" ]] && sudo $pacmanbin -S ${repoconflictingpkgsrm[@]} --ask 36 --asdeps --needed --noconfirm
     fi

--- a/libpacaur/pkgs.sh
+++ b/libpacaur/pkgs.sh
@@ -305,7 +305,7 @@ MakePkgs() {
         # build
         Note "i" $"Building ${colorW}${pkgsdeps[$i]}${reset} package(s)..."
 
-        # build then remove binary deps
+        # install then remove repo dependencies
         makeopts=(${makeopts[@]/-r/})
 
         if [[ ! $installpkg ]]; then
@@ -372,7 +372,7 @@ MakePkgs() {
             Note "i" $"Removing installed AUR dependencies..."
             sudo $pacmanbin -Rsn ${aurdepspkgs[@]} --noconfirm
         fi
-        # read removed conflicting packages
+        # readd previously removed conflicting packages
         [[ -n "${aurconflictingpkgsrm[@]}" ]] && sudo $pacmanbin -S ${aurconflictingpkgsrm[@]} --ask 36 --asdeps --needed --noconfirm
         [[ -n "${repoconflictingpkgsrm[@]}" ]] && sudo $pacmanbin -S ${repoconflictingpkgsrm[@]} --ask 36 --asdeps --needed --noconfirm
     fi

--- a/libpacaur/utils.sh
+++ b/libpacaur/utils.sh
@@ -16,7 +16,7 @@ Proceed() {
         y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$Y/$n] "
             if [[ ! $noconfirm ]]; then
                 case "$TERM" in
-                    dumb)
+                    dumb) # handle line buffering on dumb terminals
                         read -r answer
                         ;;
                     *)
@@ -39,7 +39,7 @@ Proceed() {
         n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$y/$N] "
             if [[ ! $noconfirm ]]; then
                 case "$TERM" in
-                    dumb)
+                    dumb) # handle line buffering on dumb terminals
                         read -r answer
                         ;;
                     *)


### PR DESCRIPTION
As we discussed in #443, I've added some comments to the source code in places where it was hard to understand or confusing to me. Please check them to be sure I understood correctly before merging this to `pacaur50`.

In addition, I've got observations on some of that functions:

> IgnoreChecks()
> IgnoreDepsChecks()

These two were particularly hard to understand even when their functionality is not that complex. I think that there is much repeated code here that could be converted to small functions, for instance, checking the ignore groups.

> ProviderChecks()
> ConflictChecks()

As you said, these functions are a bit convoluted, specially `ProviderChecks()`. However, their functionality is not simple and the problem they solve is not trivial either. Also, I think they are at least well documented. 
Anyways, i think that some part of them can be splitted into simple functions.

> ReinstallChecks()

I don't clearly get what are the [initial checks](https://github.com/rmarquis/pacaur/blob/5882bdd618a020880c9721b63fc66171d234e84d/libpacaur/checks.sh#L396-L398) to skip the packages:

```sh
[[ ! $foreign ]] && [[ ! " ${aurpkgs[@]} " =~ " ${depsAname[$i]} " || " ${aurconflictingpkgs[@]} " =~ " ${depsAname[$i]} " ]] && continue
[[ -z "${depsQver[$i]}" || "${depsQver[$i]}" = '#' || $(vercmp "${depsAver[$i]}" "${depsQver[$i]}") -gt 0 ]] && continue
[[ ! $installpkg && ! " ${aurdepspkgs[@]} " =~ " ${depsAname[$i]} " ]] && continue
```
> OutofdateChecks()
> OrphanChecks()
> GetBuiltPkg()
> CleanCache()
> Proceed()

These functions are nice and a good example to follow when other functions are split. They do one thing at the time on a few lines.

> Prompt()

Binary size computation could be extracted from here and put into an `utils` simple function.

> EditPkgs()

Here, there are many nested loops and they are a bit hard to follow. Some functions could be created to handle this. I've noticed that options taken from global configuration and use as conditional make the code a lot of harder to read (p.e. `$noconfirm`). 

> MakePkgs()

I'm positive that a substantial part of this function can be extracted to new functions. A clear example is the fragment of code where is checked the integrity. I am also wondering if the new orphan checks couldn't use `OrphanCheck()` in some way. As you suggested, some parts of the code should be rewritten using a functional approach and this is a clear target to start with.

