### PR TITLE
[WIP/RFC] Proceed: use `read -s`, wrapped in while loop

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1843,12 +1843,15 @@ CheckRequires() {
 }
 
 Proceed() {
-    local Y y N n answer
+    local Y y N n answer ret
     Y="$(gettext pacman Y)"; y="${Y,,}";
     N="$(gettext pacman N)"; n="${N,,}"
     case "$1" in
         y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$Y/$n] "
-            if [[ ! $noconfirm ]]; then
+            if [[ $noconfirm ]]; then
+              return 0
+            fi
+            while true; do
                 case "$TERM" in
                     dumb)
                         read -r answer
@@ -1857,21 +1860,21 @@ Proceed() {
                         if [[ $cleancache ]]; then
                             read -r answer
                         else
-                            read -r -n 1 answer
-                            echo
+                            read -s -r -n 1 answer
                         fi
                         ;;
                 esac
-            else
-                answer=$Y
-                echo
-            fi
-            case $answer in
-                $Y|$y|'') return 0;;
-                *) return 1;;
-            esac;;
+                case $answer in
+                    $Y|$y|'') ret=0; break;;
+                    $N|$n) ret=1; break;;
+                esac
+            done;;
         n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$y/$N] "
-            if [[ ! $noconfirm ]]; then
+            if [[ $noconfirm ]]; then
+                echo
+                return 0
+            fi
+            while true; do
                 case "$TERM" in
                     dumb)
                         read -r answer
@@ -1880,20 +1883,20 @@ Proceed() {
                         if [[ $cleancache ]]; then
                             read -r answer
                         else
-                            read -r -n 1 answer
-                            echo
+                            read -s -r -n 1 answer
                         fi
                         ;;
                 esac
-            else
-                answer=$N
-                echo
-            fi
-            case $answer in
-                $N|$n|'') return 0;;
-                *) return 1;;
-            esac;;
+                case $answer in
+                    $N|$n|'') ret=0; break;;
+                    $Y|$y) ret=1; break;;
+                esac
+            done;;
     esac
+    if [[ $TERM != dumb ]] && ! [[ $cleancache ]]; then
+        echo "$answer"
+    fi
+    return $ret
 }
 
 Note() {

--- a/pacaur
+++ b/pacaur
@@ -1843,9 +1843,14 @@ CheckRequires() {
 }
 
 Proceed() {
-    local Y y N n answer ret
+    local Y y N n answer read_line ret
     Y="$(gettext pacman Y)"; y="${Y,,}";
     N="$(gettext pacman N)"; n="${N,,}"
+    if [[ "$TERM" = dumb ]] || [[ $cleancache ]]; then
+        read_line=1
+    else
+        read_line=0
+    fi
     case "$1" in
         y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$Y/$n] "
             if [[ $noconfirm ]]; then
@@ -1853,21 +1858,15 @@ Proceed() {
                 return 0
             fi
             while true; do
-                case "$TERM" in
-                    dumb)
-                        read -r answer
-                        ;;
-                    *)
-                        if [[ $cleancache ]]; then
-                            read -r answer
-                        else
-                            read -s -r -n 1 answer
-                        fi
-                        ;;
-                esac
+                if [[ $read_line ]]; then
+                    read -r answer
+                else
+                    read -s -r -n 1 answer
+                fi
                 case $answer in
                     $Y|$y|'') ret=0; break;;
                     $N|$n) ret=1; break;;
+                    *) [[ $read_line ]] && ret=1 && break;;
                 esac
             done;;
         n)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$y/$N] "
@@ -1876,25 +1875,19 @@ Proceed() {
                 return 0
             fi
             while true; do
-                case "$TERM" in
-                    dumb)
-                        read -r answer
-                        ;;
-                    *)
-                        if [[ $cleancache ]]; then
-                            read -r answer
-                        else
-                            read -s -r -n 1 answer
-                        fi
-                        ;;
-                esac
+                if [[ $read_line ]]; then
+                    read -r answer
+                else
+                    read -s -r -n 1 answer
+                fi
                 case $answer in
                     $N|$n|'') ret=0; break;;
                     $Y|$y) ret=1; break;;
+                    *) [[ $read_line ]] && ret=0 && break;;
                 esac
             done;;
     esac
-    if [[ $TERM != dumb ]] && ! [[ $cleancache ]]; then
+    if ! [[ $read_line ]]; then
         echo "$answer"
     fi
     return $ret

--- a/pacaur
+++ b/pacaur
@@ -1849,7 +1849,8 @@ Proceed() {
     case "$1" in
         y)  printf "${colorB}%s${reset} ${colorW}%s${reset}" "::" "$2 [$Y/$n] "
             if [[ $noconfirm ]]; then
-              return 0
+                echo
+                return 0
             fi
             while true; do
                 case "$TERM" in


### PR DESCRIPTION
This makes `pacaur` handle unexpected input better, e.g. when a cursor
key is used.

TODO: It is not clear to me why `$cleancache` is handled in a special
way?! (like the dumb terminal, added in 5d5c502)
Is it meant to reflect pacman's prompt?  Is this still the case there?