### PR TITLE
Revert clean existing build before extraction

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1244,9 +1244,9 @@ MakePkgs() {
             (($? > 0)) && errmakepkg+=(${pkgsdeps[$i]})
             # extraction, prepare and pkgver update
             if [[ $silent = true ]]; then
-                makepkg -odC --skipinteg ${makeopts[@]} &>/dev/null
+                makepkg -od --skipinteg ${makeopts[@]} &>/dev/null
             else
-                makepkg -odC --skipinteg ${makeopts[@]}
+                makepkg -od --skipinteg ${makeopts[@]}
             fi
         fi
     done


### PR DESCRIPTION
ref https://github.com/rmarquis/pacaur/issues/714
ref https://github.com/Foxboron/PKGBUILDS/pull/2

The original reason for cleaning the working directory was an issue with auracles packaging rather than meson itself (incremental builds are actually one of mesons [main features](http://mesonbuild.com/index.html)), so I think it'd be appropriate to revert this change.