### PR TITLE
Fix Curl calls when -w flag is in .curlrc

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1800,7 +1800,7 @@ DownloadJson() {
     urlmax=4400
     # ensure the URI length is shorter than 4444 bytes (44 for AUR path)
     if [[ "${#urlargs}" -lt $urlmax ]]; then
-        curl -sfg --compressed -C 0 "https://$aururl$aurrpc$urlargs"
+        curl -sfg --compressed -C 0 -w "" "https://$aururl$aurrpc$urlargs"
     else
         # split and merge json stream
         j=0
@@ -1811,7 +1811,7 @@ DownloadJson() {
             urlcurl[$j]=${urlcurl[$j]}${urlarg}${urlencodedpkgs[$i]}
         done
         urlargs="$(printf "https://$aururl$aurrpc%s " "${urlcurl[@]}")"
-        curl -sfg --compressed -C 0 $urlargs | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/g;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g'
+        curl -sfg --compressed -C 0 -w "" $urlargs | sed 's/\(]}{\)\([A-Za-z0-9":,]\+[[]\)/,/g;s/\("resultcount":\)\([0-9]\+\)/"resultcount":0/g'
     fi
 }
 


### PR DESCRIPTION
Add an empty -w flag to both Curl calls in Pacaur to override the .curlrc settings.

Fixes #753 