### PR TITLE
Obtaining sudo prompt even if in stdout, fix #604

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1192,7 +1192,7 @@ MakePkgs() {
     oldoptionalpkgs=($(grep -xvf <(printf '%s\n' "${oldorphanpkgs[@]}") <(printf '%s\n' "${oldoptionalpkgs[@]}")))
 
     # initialize sudo
-    if sudo $pacmanbin -V > /dev/null; then
+    if sudo -n $pacmanbin -V > /dev/null || sudo -v; then
         [[ $sudoloop = true ]] && SudoV &
     fi
 


### PR DESCRIPTION
As described in #604, if sudo prompt is in STDOUT (e.g. when authorizing with fprintd) instead than usual STDERR, the prompt was suppressed.
This PR verifies if `pacman` requires authentication (see #418, non interactive through `-n` option and redirecting the output to `/dev/null`) before asking for generic sudo authentication.
The same modification should not be needed in the privileges preservation routine `SudoV` at line 1925.