### PR TITLE
suppress STDERR output from sudo -n, fixup to #766

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1192,7 +1192,7 @@ MakePkgs() {
     oldoptionalpkgs=($(grep -xvf <(printf '%s\n' "${oldorphanpkgs[@]}") <(printf '%s\n' "${oldoptionalpkgs[@]}")))
 
     # initialize sudo
-    if sudo -n $pacmanbin -V > /dev/null || sudo -v; then
+    if sudo -n $pacmanbin -V &> /dev/null || sudo -v; then
         [[ $sudoloop = true ]] && SudoV &
     fi
 


### PR DESCRIPTION
The modification I made in #766 added an useless output message in STDERR from `sudo -n` saying `sudo: a password is required`, this commit gets rid of that message.