### PR TITLE
correct zh_CN translation

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -287,7 +287,7 @@ msgstr "正在删除已安装的 AUR 依赖..."
 
 #: pacaur:1281
 msgid "${colorW}$i${reset} is now an ${colorY}orphan${reset} package"
-msgstr "${colorW}$i${reset} 现在是 ${colorY}无人维护的${reset} 软件包"
+msgstr "${colorW}$i${reset} 现在是 ${colorY}不被需要的${reset} 软件包"
 
 #: pacaur:1287
 msgid "${colorW}$i${reset} is now an ${colorY}optional${reset} package"


### PR DESCRIPTION
The "orphan" package in pacman repos actually means "not needed by any other package" (queried by -Qtdq) instead of "not maintained" (无人维护的).