### PR TITLE
Use --no-ext-diff option when running `git diff`.

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1105,7 +1105,7 @@ EditPkgs() {
             if [[ ! $displaybuildfiles = none ]]; then
                 if [[ $displaybuildfiles = diff && -e ".git/HEAD.prev" ]]; then
                     # show diff
-                    diffcmd="git diff $(cut -f1 .git/HEAD.prev) -- . ':!\.SRCINFO'"
+                    diffcmd="git diff --no-ext-diff $(cut -f1 .git/HEAD.prev) -- . ':!\.SRCINFO'"
                     if [[ -n "$(eval "$diffcmd")" ]]; then
                         if Proceed "y" $"View $i build files diff?"; then
                             eval "$diffcmd"


### PR DESCRIPTION
If the user has an external diff command set up in their git config, such as vimdiff, things go haywire during installation.