### PR TITLE
Update zsh.completion to work with hyphenless args

### DIFF
--- a/zsh.completion
+++ b/zsh.completion
@@ -56,7 +56,8 @@ _pacaur_opts_commands=(
     cleanall\:'Clean all AUR packages and clones'
     {-h,--help}\:'Display usage'
     '-V\:Display pacman version'
-    {-v,--version}\:'Display pacaur version'))"
+    {-v,--version}\:'Display pacaur version'
+    ))"
 )
 
 _pacaur_opts_extended=(

--- a/zsh.completion
+++ b/zsh.completion
@@ -168,7 +168,7 @@ _pacaur_opts_sync_modifiers=(
 # handles check subcommand
 _pacaur_action_check() {
     _arguments -s : \
-        "*:check:((--devel\:'Consider AUR development packages upgrade' --needed\:'Do not reinstall up to date packages'))"
+        "*:check:(( --devel\:'Consider AUR development packages upgrade' ))"
 }
 
 # handles info subcommand
@@ -552,10 +552,16 @@ case $args in
         if [[ ${words[2]} != -* && ${CURRENT} -gt 2  ]] then
             case ${words[2]} in
                 sync)
-                    _pacaur_action_sync
+                    _pacaur_action_sync 
                     ;;
                 upgrade)
-                    _pacaur_action_upgrade
+                    _arguments -s : \
+                        '--devel[Consider AUR development packages upgrade]' \
+                        '--needed[Do not reinstall up to date packages]' \
+                        "$_pacaur_opts_common[@]" \
+                        "$_pacaur_opts_extended[@]" \
+                        "$_pacaur_opts_sync_modifiers[@]" \
+                        '*:packages:'$completion_repo
                     ;;
                 check)
                     _pacaur_action_check

--- a/zsh.completion
+++ b/zsh.completion
@@ -181,6 +181,20 @@ _pacaur_action_info() {
         '*:info:_pacaur_completions_aur_packages'
 }
 
+# handles clean subcommand
+_pacaur_action_clean() {
+    if [[ $AURDEST ]] then;
+        CLONEDIR=$AURDEST
+    elif [[ $XDG_CACHE_HOME && -a $XDG_CACHE_HOME/pacaur ]]; then
+        CLONEDIR=$XDG_CACHE_HOME/pacaur
+    else
+        CLONEDIR=$HOME/.cache/pacaur 
+    fi
+    _arguments -s :  \
+        "*:clean:($(ls $CLONEDIR))" \
+        "$_pacaur_opts_common[@]"
+ }        
+
 # handles --help subcommand
 _pacaur_action_help() {
     _arguments -s : \
@@ -554,6 +568,13 @@ case $args in
                     ;;
                 buildonly) 
                     _pacaur_action_sync
+                    ;;
+                clean)
+                    _pacaur_action_clean
+                    ;;
+                cleanall)
+                    _arguments -s : \
+                        "$_pacaur_opts_common[@]"                   
                     ;;
             esac
         else

--- a/zsh.completion
+++ b/zsh.completion
@@ -39,25 +39,24 @@ fi
 
 # options for passing to _arguments: main pacaur commands
 _pacaur_opts_commands=(
-    {-D,--database}'[Modify database]'
-    {-Q,--query}'[Query the package database]'
-    {-R,--remove}'[Remove a package from the system]'
-    {-S,--sync}'[Synchronize packages]'
-    {-T,--deptest}'[Check if dependencies are installed]'
-    {-U,--upgrade}'[Upgrade a package]'
-
-    {sync}'[Clone, build and install target(s)]'
-    {search}'[Search AUR package names and descriptions]'
-    {info}'[Show info for target(s)]'
-    {buildonly}'[Clone and build target(s)]'
-    {upgrade}'[Upgrade AUR package(s)]'
-    {check}'[Check for AUR upgrade(s)]'
-    {clean}'[Clean AUR package(s) and clone(s)]'
-    {cleanall}'[Clean all AUR packages and clones]'
-    {-h,--help}'[Display usage]'
-    '-V[Display pacman version]'
-    {-v,--version}'[Display pacaur version]'
-    '(-h --help)'{-h,--help}'[Display usage]'
+    ":pacaur_commands:((
+    {-D,--database}\:'Modify database'
+    {-Q,--query}\:'Query the package database'
+    {-R,--remove}\:'Remove a package from the system'
+    {-S,--sync}\:'Synchronize packages'
+    {-T,--deptest}\:'Check if dependencies are installed'
+    {-U,--upgrade}\:'Upgrade a package'
+    sync\:'Clone, build and install target(s)'
+    search\:'Search AUR package names and descriptions'
+    info\:'Show info for target(s)'
+    buildonly\:'Clone and build target(s)'
+    upgrade\:'Upgrade AUR package(s)'
+    check\:'Check for AUR upgrade(s)'
+    clean\:'Clean AUR package(s) and clone(s)'
+    cleanall\:'Clean all AUR packages and clones'
+    {-h,--help}\:'Display usage'
+    '-V\:Display pacman version'
+    {-v,--version}\:'Display pacaur version'))"
 )
 
 _pacaur_opts_extended=(

--- a/zsh.completion
+++ b/zsh.completion
@@ -170,6 +170,17 @@ _pacaur_action_check() {
     _arguments -s : \
         "*:check:((--devel\:'Consider AUR development packages upgrade' --needed\:'Do not reinstall up to date packages'))"
 }
+
+# handles info subcommand
+_pacaur_action_info() {
+   _arguments -s : \
+        "$_pacaur_opts_common[@]" \
+        "$_pacaur_opts_extended[@]" \
+        "$_pacaur_opts_sync_actions[@]" \
+        "$_pacaur_opts_sync_modifiers[@]" \
+        '*:info:_pacaur_completions_aur_packages'
+}
+
 # handles --help subcommand
 _pacaur_action_help() {
     _arguments -s : \
@@ -422,7 +433,12 @@ for tmp in $words; do
 done
 
 # handle repository filter
-if (( $+words[(r)--aur] || $+words[(r)-S*a*] || $+words[(r)sync] )); then
+if [[ $words[2] != -* ]]; then
+    isaur=1
+else
+    isaur=0
+fi
+if (( $+words[(r)--aur] || $+words[(r)-S*a*] || $isaur  )); then
     completion_repo='_pacaur_completions_aur_packages'
 elif (( $+words[(r)--repo] || $+words[(r)-S*r*] )); then
     completion_repo='_pacaur_completions_all_packages'
@@ -519,20 +535,29 @@ case $args in
         _pacaur_action_version
         ;;
     *)
-        case ${words[2]:#-*} in
-            sync*)
-                _pacaur_action_sync
-                ;;
-            upgrade*)
-                _pacaur_action_upgrade
-                ;;
-            check*)
-                _pacaur_action_check
-                ;;
-            search*)
-                _pacaur_action_sync
-            *)
-                case ${(M)words:#--*} in
+        if [[ ${words[2]} != -* && ${CURRENT} -gt 2  ]] then
+            case ${words[2]} in
+                sync)
+                    _pacaur_action_sync
+                    ;;
+                upgrade)
+                    _pacaur_action_upgrade
+                    ;;
+                check)
+                    _pacaur_action_check
+                    ;;
+                search)
+                    _pacaur_action_sync
+                    ;;
+                info)
+                    _pacaur_action_info
+                    ;;
+                buildonly) 
+                    _pacaur_action_sync
+                    ;;
+            esac
+        else
+            case ${(M)words:#--*} in
                     *--help*)
                         if (( ${(w)#cmds} == 1 )); then
                             _pacaur_action_help
@@ -558,10 +583,9 @@ case $args in
                     *)
                         _pacaur_action_none
                         ;;
-                esac
-                ;;
-        esac
-        ;;
+                esac      
+        fi
+;;
 esac
 
 # vim:set ts=4 sw=2 et:

--- a/zsh.completion
+++ b/zsh.completion
@@ -165,6 +165,11 @@ _pacaur_opts_sync_modifiers=(
     '--force[Overwrite conflicting files]'
 )
 
+# handles check subcommand
+_pacaur_action_check() {
+    _arguments -s : \
+        "*:check:((--devel\:'Consider AUR development packages upgrade' --needed\:'Do not reinstall up to date packages'))"
+}
 # handles --help subcommand
 _pacaur_action_help() {
     _arguments -s : \
@@ -248,7 +253,7 @@ _pacaur_action_sync() {
         state=sync_clean
     elif (( $+words[(r)--groups] )); then
         state=sync_group
-    elif (( $+words[(r)--search] )); then
+    elif (( $+words[(r)--search] || $+words[(r)search] )); then
         state=sync_search
     fi
 
@@ -417,7 +422,7 @@ for tmp in $words; do
 done
 
 # handle repository filter
-if (( $+words[(r)--aur] || $+words[(r)-S*a*] )); then
+if (( $+words[(r)--aur] || $+words[(r)-S*a*] || $+words[(r)sync] )); then
     completion_repo='_pacaur_completions_aur_packages'
 elif (( $+words[(r)--repo] || $+words[(r)-S*r*] )); then
     completion_repo='_pacaur_completions_all_packages'
@@ -514,38 +519,46 @@ case $args in
         _pacaur_action_version
         ;;
     *)
-
-        case ${(M)words:#--*} in
-            *--help*)
-                if (( ${(w)#cmds} == 1 )); then
-                    _pacaur_action_help
-                else
-                    return 0;
-                fi
-                ;;
-            *--sync*)
+        case ${words[2]:#-*} in
+            sync*)
                 _pacaur_action_sync
                 ;;
-            *--query*)
-                _pacaur_action_query
-                ;;
-            *--remove*)
-                _pacaur_action_remove
-                ;;
-            *--deptest*)
-                _pacaur_action_deptest
-                ;;
-            *--database*)
-                _pacaur_action_database
-                ;;
-            *--version*)
-                _pacaur_action_version
-                ;;
-            *--upgrade*)
+            upgrade*)
                 _pacaur_action_upgrade
                 ;;
+            check*)
+                _pacaur_action_check
+                ;;
+            search*)
+                _pacaur_action_sync
             *)
-                _pacaur_action_none
+                case ${(M)words:#--*} in
+                    *--help*)
+                        if (( ${(w)#cmds} == 1 )); then
+                            _pacaur_action_help
+                        else
+                            return 0;
+                        fi
+                        ;;
+                    *--version*)
+                        _pacaur_action_version
+                        ;;
+                    *--query*)
+                        _pacaur_action_query
+                        ;;
+                    *--remove*)
+                        _pacaur_action_remove
+                        ;;
+                    *--deptest*)
+                        _pacaur_action_deptest
+                        ;;
+                    *--database*)
+                        _pacaur_action_database
+                        ;;
+                    *)
+                        _pacaur_action_none
+                        ;;
+                esac
                 ;;
         esac
         ;;


### PR DESCRIPTION
As _arguments can't have a hyphenless arg, _describe & _alternative don't seem to support short AND long options (at least I didn't find how), and to prevent rewriting most of the file I put an action to parse all the options.
English is not my language, I'm trying my best :+1: 