### PR TITLE
removed gratipay as donation option

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -423,8 +423,7 @@ Remy Marquis E<lt>remy.marquis@gmail.comE<gt>
 If you feel great pity for the present maintainer that has to constantly cope
 with users that don't want to read man pages and refuse to take responsibility
 for their own system, you can send me funny cat pictures. Alternatively, you
-can send a donation via PayPal to the above email address or via Gratipay at
-https://gratipay.com/pacaur/.
+can send a donation via PayPal to the above email address.
 
 I would also suggest to donate to a charitable organization of your choice
 should you believe that your money could make a bigger difference there.


### PR DESCRIPTION
Gratipay is closing, see https://gratipay.news/the-end-cbfba8f50981